### PR TITLE
Add Integers into parser and solvers

### DIFF
--- a/.github/workflows/CryptatorTest.yml
+++ b/.github/workflows/CryptatorTest.yml
@@ -6,10 +6,10 @@ jobs :
   steps:
    - name: Checkhout the repository
      uses: actions/checkout@v3
-   - name: Set up JDK 11
+   - name: Set up JDK 17
      uses: actions/setup-java@v3
      with:
-      java-version: '11'
+      java-version: '17'
       distribution: 'adopt'
       cache: 'maven'
    - name: Test with Maven

--- a/pom.xml
+++ b/pom.xml
@@ -9,211 +9,213 @@
     See LICENSE file in the project root for full license information.
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-	<modelVersion>4.0.0</modelVersion>
-	<groupId>fr.univ-cotedazur</groupId>
-	<artifactId>cryptator</artifactId>
-	<packaging>jar</packaging>
-	<version>0.5.0-SNAPSHOT</version>
-	<name>cryptator</name>
-	<description>Constraint-based cryptarithm solver</description>
-	<url>https://github.com/arnaud-m/cryptator</url>
-	<licenses>
-		<license>
-			<name>BSD 3-Clause License</name>
-			<url>https://spdx.org/licenses/BSD-3-Clause.html</url>
-		</license>
-	</licenses>
-	<developers>
-		<developer>
-			<name>Arnaud Malapert</name>
-			<email>arnaud.malapert@univ-cotedazur.fr</email>
-			<organization>Université Côte d'Azur</organization>
-			<organizationUrl>http://www.i3s.unice.fr/~malapert/</organizationUrl>
-		</developer>
-		<developer>
-			<name>Marie Pelleau</name>
-			<email>marie.pelleau@univ-cotedazur.fr</email>
-			<organization>Université Côte d'Azur</organization>
-			<organizationUrl>http://www.i3s.unice.fr/~pelleau/</organizationUrl>
-		</developer>
-		<developer>
-			<name>Margaux Schmied</name>
-			<email>margaux.schmied@etu.univ-cotedazur.fr</email>
-			<organization>Université Côte d'Azur</organization>
-		</developer>
-	</developers>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>fr.univ-cotedazur</groupId>
+    <artifactId>cryptator</artifactId>
+    <packaging>jar</packaging>
+    <version>0.5.0-SNAPSHOT</version>
+    <name>cryptator</name>
+    <description>Constraint-based cryptarithm solver</description>
+    <url>https://github.com/arnaud-m/cryptator</url>
+    <licenses>
+        <license>
+            <name>BSD 3-Clause License</name>
+            <url>https://spdx.org/licenses/BSD-3-Clause.html</url>
+        </license>
+    </licenses>
+    <developers>
+        <developer>
+            <name>Arnaud Malapert</name>
+            <email>arnaud.malapert@univ-cotedazur.fr</email>
+            <organization>Université Côte d'Azur</organization>
+            <organizationUrl>http://www.i3s.unice.fr/~malapert/</organizationUrl>
+        </developer>
+        <developer>
+            <name>Marie Pelleau</name>
+            <email>marie.pelleau@univ-cotedazur.fr</email>
+            <organization>Université Côte d'Azur</organization>
+            <organizationUrl>http://www.i3s.unice.fr/~pelleau/</organizationUrl>
+        </developer>
+        <developer>
+            <name>Margaux Schmied</name>
+            <email>margaux.schmied@etu.univ-cotedazur.fr</email>
+            <organization>Université Côte d'Azur</organization>
+        </developer>
+    </developers>
 
-	<properties>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.build.timestamp.format>yyyy</maven.build.timestamp.format>
-		<!-- Java source/target to use for compilation. -->
-		<javac.target>11</javac.target>
-		<javac.source>11</javac.source>
-	</properties>
-	<dependencies>
-		<!-- https://mvnrepository.com/artifact/args4j/args4j -->
-		<dependency>
-			<groupId>args4j</groupId>
-			<artifactId>args4j</artifactId>
-			<version>2.33</version>
-		</dependency>
-		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<version>4.13.2</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.antlr</groupId>
-			<artifactId>antlr4-runtime</artifactId>
-			<version>4.9.2</version>
-		</dependency>
-		<dependency>
-			<groupId>antlr</groupId>
-			<artifactId>antlr</artifactId>
-			<version>2.7.7</version>
-		</dependency>
-		<dependency>
-			<groupId>org.choco-solver</groupId>
-			<artifactId>choco-solver</artifactId>
-			<version>4.10.6</version>
-		</dependency>
-		<dependency>
-			<groupId>guru.nidi</groupId>
-			<artifactId>graphviz-java</artifactId>
-			<version>0.18.1</version>
-		</dependency>
-		<!-- https://mvnrepository.com/artifact/org.slf4j/slf4j-nop -->
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-nop</artifactId>
-			<version>1.7.32</version>
-		</dependency>
-	<!-- 	<dependency>
-			<groupId>ch.qos.logback</groupId>
-			<artifactId>logback-classic</artifactId>
-			<version>1.2.3</version>
-		</dependency>  -->
-	<!-- https://mvnrepository.com/artifact/com.ibm.icu/icu4j -->
-	<dependency>
-	    <groupId>com.ibm.icu</groupId>
-	    <artifactId>icu4j</artifactId>
-	    <version>69.1</version>
-	</dependency>
-	<!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-databind -->
-	<dependency>
-    	<groupId>com.fasterxml.jackson.core</groupId>
-    	<artifactId>jackson-databind</artifactId>
-    	<version>2.13.0</version>
-    	<scope>test</scope>
-	</dependency>
-	</dependencies>
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.8.1</version>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.build.timestamp.format>yyyy</maven.build.timestamp.format>
+        <!-- Java source/target to use for compilation. -->
+        <javac.target>17</javac.target>
+        <javac.source>17</javac.source>
+    </properties>
+    <dependencies>
+        <!-- https://mvnrepository.com/artifact/args4j/args4j -->
+        <dependency>
+            <groupId>args4j</groupId>
+            <artifactId>args4j</artifactId>
+            <version>2.33</version>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.antlr</groupId>
+            <artifactId>antlr4-runtime</artifactId>
+            <version>4.9.2</version>
+        </dependency>
+        <dependency>
+            <groupId>antlr</groupId>
+            <artifactId>antlr</artifactId>
+            <version>2.7.7</version>
+        </dependency>
+        <dependency>
+            <groupId>org.choco-solver</groupId>
+            <artifactId>choco-solver</artifactId>
+            <version>4.10.6</version>
+        </dependency>
+        <dependency>
+            <groupId>guru.nidi</groupId>
+            <artifactId>graphviz-java</artifactId>
+            <version>0.18.1</version>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/org.slf4j/slf4j-nop -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-nop</artifactId>
+            <version>1.7.32</version>
+        </dependency>
+        <!-- 	<dependency>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-classic</artifactId>
+                <version>1.2.3</version>
+            </dependency>  -->
+        <!-- https://mvnrepository.com/artifact/com.ibm.icu/icu4j -->
+        <dependency>
+            <groupId>com.ibm.icu</groupId>
+            <artifactId>icu4j</artifactId>
+            <version>69.1</version>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-databind -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.13.0</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
 
-				<!-- defaults for compile and testCompile -->
-				<configuration>
-					<encoding>UTF-8</encoding>
-					<showDeprecation>true</showDeprecation>
-					<showWarnings>true</showWarnings>
-					<!-- Only required when JAVA_HOME isn't at least Java 9 and when haven't
-						configured the maven-toolchains-plugin -->
-					<jdkToolchain>
-						<version>11</version>
-					</jdkToolchain>
-					<release>11</release>
-				</configuration>
-			</plugin>
-			<plugin>
-				<groupId>com.mycila</groupId>
-				<artifactId>license-maven-plugin</artifactId>
-				<version>3.0</version>
-				<configuration>
-					<header>src/etc/header.txt</header>
-					<properties>
-						<year>${maven.build.timestamp}</year>
-						<owner>Université Côte d'Azur</owner>
-						<project>
-							${project.name}
-						</project>
-						<prurl>${project.url}</prurl>
-					</properties>
-					<mapping>
-						<template>JAVADOC_STYLE</template>
-					</mapping>
-					<includes>
-						<include>src/*/java/**/*.java</include>
-						<include>**/pom.xml</include>
-					</includes>
-				</configuration>
-				<executions>
-					<execution>
-						<phase>compile</phase>
-						<goals>
-							<goal>format</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-jar-plugin</artifactId>
-				<version>3.2.0</version>
-                                <!-- The jar goal is in the default lifecycle -->
-	                        <!-- <executions> -->
-				<!-- 	<execution> -->
-				<!-- 		<goals> -->
-				<!-- 			<goal>jar</goal> -->
-				<!-- 			<!-\- <goal>test-jar</goal> -\-> -->
-				<!-- 		</goals> -->
-				<!-- 	</execution> -->
-				<!-- </executions> -->
-				<configuration>
-				    <archive>
-					<manifest>
-					    <addClasspath>true</addClasspath>
-					</manifest>
-				    </archive>
-				</configuration>
-			</plugin>
-			<plugin>
-				<artifactId>maven-assembly-plugin</artifactId>
-				<version>3.3.0</version>
-				<executions>
-					<execution>
-						<id>make-assembly</id>
-						<phase>package</phase>
-						<goals>
-							<goal>single</goal>
-						</goals>
-						<configuration>
-							<descriptors>
-								<descriptor>./src/assembly/with-dep.xml</descriptor>
-							</descriptors>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
-				<groupId>org.antlr</groupId>
-				<artifactId>antlr4-maven-plugin</artifactId>
-				<version>4.9.2</version>
-				<executions>
-					<execution>
-						<goals>
-							<goal>antlr4</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-		</plugins>
-	</build>
+                <!-- defaults for compile and testCompile -->
+                <configuration>
+                    <encoding>UTF-8</encoding>
+                    <showDeprecation>true</showDeprecation>
+                    <showWarnings>true</showWarnings>
+                    <!-- Only required when JAVA_HOME isn't at least Java 9 and when haven't
+                        configured the maven-toolchains-plugin -->
+                    <jdkToolchain>
+                        <version>17</version>
+                    </jdkToolchain>
+                    <release>17</release>
+                    <source>16</source>
+                    <target>16</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>com.mycila</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <version>3.0</version>
+                <configuration>
+                    <header>src/etc/header.txt</header>
+                    <properties>
+                        <year>${maven.build.timestamp}</year>
+                        <owner>Université Côte d'Azur</owner>
+                        <project>
+                            ${project.name}
+                        </project>
+                        <prurl>${project.url}</prurl>
+                    </properties>
+                    <mapping>
+                        <template>JAVADOC_STYLE</template>
+                    </mapping>
+                    <includes>
+                        <include>src/*/java/**/*.java</include>
+                        <include>**/pom.xml</include>
+                    </includes>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>format</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.2.0</version>
+                <!-- The jar goal is in the default lifecycle -->
+                <!-- <executions> -->
+                <!-- 	<execution> -->
+                <!-- 		<goals> -->
+                <!-- 			<goal>jar</goal> -->
+                <!-- 			<!-\- <goal>test-jar</goal> -\-> -->
+                <!-- 		</goals> -->
+                <!-- 	</execution> -->
+                <!-- </executions> -->
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <addClasspath>true</addClasspath>
+                        </manifest>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>3.3.0</version>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <descriptors>
+                                <descriptor>./src/assembly/with-dep.xml</descriptor>
+                            </descriptors>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.antlr</groupId>
+                <artifactId>antlr4-maven-plugin</artifactId>
+                <version>4.9.2</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>antlr4</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/src/main/antlr4/Cryptator.g4
+++ b/src/main/antlr4/Cryptator.g4
@@ -23,8 +23,9 @@ equation returns [ICryptaNode node]  //create a node of the tree corresponding t
         | left=expression COMPARATOR right=expression {$node=new CryptaNode($COMPARATOR.getText(), $left.node, $right.node);};
                  
 
-expression returns [ICryptaNode node]: //create recursively the tree of expressions with priority and return the root of the tree
-            word {$node=new CryptaLeaf($word.text);} //create a node of the tree corresponding to a leaf and return this node
+expression returns [ICryptaNode node] //create recursively the tree of expressions with priority and return the root of the tree
+            : word {$node=new CryptaLeaf($word.text);} //create a node of the tree corresponding to a leaf and return this node
+            | '\'' number '\'' {$node=new CryptaLeaf($word.text);}
             | '(' expression ')' {$node=$expression.node;}
             | e1=expression modORpow e2=expression {$node=new CryptaNode($modORpow.text, $e1.node, $e2.node);} //create a node of the tree corresponding to an operation and return this node
             | sub expression {$node=new CryptaNode($sub.text, new CryptaLeaf(), $expression.node);}
@@ -32,7 +33,9 @@ expression returns [ICryptaNode node]: //create recursively the tree of expressi
             | e1=expression addORsub e2=expression {$node=new CryptaNode($addORsub.text, $e1.node, $e2.node);};
 
 word :  //additional token to simplify the passage in parameter
-    (SYMBOL)+; 
+    (SYMBOL)+;
+
+number : (DIGIT)+;
     
 modORpow : '%' | '^';
 
@@ -47,6 +50,8 @@ sub : '-';
 COMPARATOR : '=' | '!=' | '<' | '>' | '<=' | '>=';
 
 SYMBOL : [a-zA-Z0-9\u0080-\uFFFF] {};
+
+DIGIT : [0-9] {};
 
 WHITESPACE : ( '\t' | ' ' | '\r' | '\n'| '\u000C' )+ -> skip ;
 

--- a/src/main/antlr4/Cryptator.g4
+++ b/src/main/antlr4/Cryptator.g4
@@ -6,6 +6,7 @@ package cryptator.parser;
 import cryptator.specs.ICryptaNode;
 import cryptator.tree.CryptaNode;
 import cryptator.tree.CryptaLeaf;
+import cryptator.tree.CryptaConstant;
 
 }
 
@@ -25,7 +26,7 @@ equation returns [ICryptaNode node]  //create a node of the tree corresponding t
 
 expression returns [ICryptaNode node] //create recursively the tree of expressions with priority and return the root of the tree
             : word {$node=new CryptaLeaf($word.text);} //create a node of the tree corresponding to a leaf and return this node
-            | '\'' number '\'' {$node=new CryptaLeaf($number.text, true);}
+            | '\'' number '\'' {$node=new CryptaConstant($number.text);}
             | '(' expression ')' {$node=$expression.node;}
             | e1=expression modORpow e2=expression {$node=new CryptaNode($modORpow.text, $e1.node, $e2.node);} //create a node of the tree corresponding to an operation and return this node
             | sub expression {$node=new CryptaNode($sub.text, new CryptaLeaf(), $expression.node);}

--- a/src/main/antlr4/Cryptator.g4
+++ b/src/main/antlr4/Cryptator.g4
@@ -25,7 +25,7 @@ equation returns [ICryptaNode node]  //create a node of the tree corresponding t
 
 expression returns [ICryptaNode node] //create recursively the tree of expressions with priority and return the root of the tree
             : word {$node=new CryptaLeaf($word.text);} //create a node of the tree corresponding to a leaf and return this node
-            | '\'' number '\'' {$node=new CryptaLeaf($word.text);}
+            | '\'' number '\'' {$node=new CryptaLeaf($number.text);}
             | '(' expression ')' {$node=$expression.node;}
             | e1=expression modORpow e2=expression {$node=new CryptaNode($modORpow.text, $e1.node, $e2.node);} //create a node of the tree corresponding to an operation and return this node
             | sub expression {$node=new CryptaNode($sub.text, new CryptaLeaf(), $expression.node);}
@@ -33,7 +33,7 @@ expression returns [ICryptaNode node] //create recursively the tree of expressio
             | e1=expression addORsub e2=expression {$node=new CryptaNode($addORsub.text, $e1.node, $e2.node);};
 
 word :  //additional token to simplify the passage in parameter
-    (SYMBOL)+;
+    (SYMBOL|DIGIT)+;
 
 number : (DIGIT)+;
     
@@ -49,7 +49,7 @@ sub : '-';
 
 COMPARATOR : '=' | '!=' | '<' | '>' | '<=' | '>=';
 
-SYMBOL : [a-zA-Z0-9\u0080-\uFFFF] {};
+SYMBOL : [a-zA-Z\u0080-\uFFFF] {};
 
 DIGIT : [0-9] {};
 

--- a/src/main/antlr4/Cryptator.g4
+++ b/src/main/antlr4/Cryptator.g4
@@ -25,7 +25,7 @@ equation returns [ICryptaNode node]  //create a node of the tree corresponding t
 
 expression returns [ICryptaNode node] //create recursively the tree of expressions with priority and return the root of the tree
             : word {$node=new CryptaLeaf($word.text);} //create a node of the tree corresponding to a leaf and return this node
-            | '\'' number '\'' {$node=new CryptaLeaf($number.text);}
+            | '\'' number '\'' {$node=new CryptaLeaf($number.text, true);}
             | '(' expression ')' {$node=$expression.node;}
             | e1=expression modORpow e2=expression {$node=new CryptaNode($modORpow.text, $e1.node, $e2.node);} //create a node of the tree corresponding to an operation and return this node
             | sub expression {$node=new CryptaNode($sub.text, new CryptaLeaf(), $expression.node);}

--- a/src/main/java/cryptator/solver/AbstractModelerNodeConsumer.java
+++ b/src/main/java/cryptator/solver/AbstractModelerNodeConsumer.java
@@ -8,101 +8,96 @@
  */
 package cryptator.solver;
 
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
-
+import cryptator.config.CryptaConfig;
+import cryptator.specs.ICryptaNode;
+import cryptator.specs.ITraversalNodeConsumer;
 import org.chocosolver.solver.Model;
 import org.chocosolver.solver.constraints.Constraint;
 import org.chocosolver.solver.variables.IntVar;
 import org.chocosolver.util.tools.ArrayUtils;
 
-import cryptator.config.CryptaConfig;
-import cryptator.specs.ICryptaNode;
-import cryptator.specs.ITraversalNodeConsumer;
+import java.util.*;
 
 public abstract class AbstractModelerNodeConsumer implements ITraversalNodeConsumer {
 
-	public final Model model;
-	public final CryptaConfig config;
-	public final Map<Character, IntVar> symbolsToVariables;
-	protected final Set<Character> firstSymbols;
+    public final Model model;
+    public final CryptaConfig config;
+    public final Map<Character, IntVar> symbolsToVariables;
+    protected final Set<Character> firstSymbols;
 
 
-	protected AbstractModelerNodeConsumer(Model model, CryptaConfig config) {
-		super();
-		this.model = model;
-		this.config = config;
-		symbolsToVariables = new HashMap<>();
-		firstSymbols = new HashSet<>();		
-	}
+    protected AbstractModelerNodeConsumer(Model model, CryptaConfig config) {
+        super();
+        this.model = model;
+        this.config = config;
+        symbolsToVariables = new HashMap<>();
+        firstSymbols = new HashSet<>();
+    }
 
-	private IntVar createSymbolVar(char symbol) {
-		return model.intVar(String.valueOf(symbol), 0, config.getArithmeticBase()-1, false);
-	}
+    private IntVar createSymbolVar(char symbol) {
+        return model.intVar(String.valueOf(symbol), 0, config.getArithmeticBase() - 1, false);
+    }
 
-	protected IntVar getSymbolVar(char symbol) {
-		return symbolsToVariables.computeIfAbsent(symbol, this::createSymbolVar);	
-	}
+    protected IntVar getSymbolVar(char symbol) {
+        return symbolsToVariables.computeIfAbsent(symbol, this::createSymbolVar);
+    }
 
-	private IntVar[] getGCCVars() {
-		final Collection<IntVar> vars = symbolsToVariables.values();
-		return vars.toArray(new IntVar[vars.size()]);
-	}
+    private IntVar[] getGCCVars() {
+        final Collection<IntVar> vars = symbolsToVariables.values();
+        return vars.toArray(new IntVar[vars.size()]);
+    }
 
-	private IntVar[] getGCCOccs(int lb, int ub) {
-		return model.intVarArray("O", config.getArithmeticBase(), lb, ub, false);
-	}
+    private IntVar[] getGCCOccs(int lb, int ub) {
+        return model.intVarArray("O", config.getArithmeticBase(), lb, ub, false);
+    }
 
-	@Override
-	public void accept(ICryptaNode node, int numNode) {
-		if(node.isLeaf()) {
-			final char[] w = node.getWord();
-			if(w.length > 0) firstSymbols.add(node.getWord()[0]);
-		}	
-	}
+    @Override
+    public void accept(ICryptaNode node, int numNode) {
+        if (node.isLeaf() && !node.isConstant()) {
+            final char[] w = node.getWord();
+            if (w.length > 0) firstSymbols.add(node.getWord()[0]);
+        }
+    }
 
-	private void postFirstSymbolConstraints() {
-		if(! config.getAllowLeadingZeros()) {
-			for (Character symbol : firstSymbols) {
-				getSymbolVar(symbol).gt(0).post();
-			}
-		}
-	}
+    private void postFirstSymbolConstraints() {
+        if (!config.getAllowLeadingZeros()) {
+            for (Character symbol : firstSymbols) {
+                getSymbolVar(symbol).gt(0).post();
+            }
+        }
+    }
 
-	private Constraint globalCardinalityConstraint() {
-		final IntVar[] vars = getGCCVars();
-		final int n = vars.length;
-		if(n == 0) return model.trueConstraint();
+    private Constraint globalCardinalityConstraint() {
+        final IntVar[] vars = getGCCVars();
+        final int n = vars.length;
+        if (n == 0) return model.trueConstraint();
 
-		final int maxOcc = config.getMaxDigitOccurence(n);		
-		if(maxOcc == 1) {
-			return model.allDifferent(vars);
-		} else {
-			final int minOcc = config.getMinDigitOccurence(n);
-			final int[] values = ArrayUtils.array(0, config.getArithmeticBase() -1);
-			return model.globalCardinality(
-					vars, values, 
-					getGCCOccs(minOcc, maxOcc), 
-					true);
+        final int maxOcc = config.getMaxDigitOccurence(n);
+        if (maxOcc == 1) {
+            return model.allDifferent(vars);
+        } else {
+            final int minOcc = config.getMinDigitOccurence(n);
+            final int[] values = ArrayUtils.array(0, config.getArithmeticBase() - 1);
+            return model.globalCardinality(
+                    vars, values,
+                    getGCCOccs(minOcc, maxOcc),
+                    true);
 
-		}
-	}
+        }
+    }
 
-	protected abstract void postCryptarithmEquationConstraint() throws CryptaModelException;
+    protected abstract void postCryptarithmEquationConstraint() throws CryptaModelException;
 
-	public void postConstraints() throws CryptaModelException {
-		postFirstSymbolConstraints();
-		globalCardinalityConstraint().post();
-		postCryptarithmEquationConstraint();
+    public void postConstraints() throws CryptaModelException {
+        postFirstSymbolConstraints();
+        globalCardinalityConstraint().post();
+        postCryptarithmEquationConstraint();
 
 
-	}
+    }
 
-	public CryptaModel buildCryptaModel() {
-		return new CryptaModel(model, symbolsToVariables);
-	}
+    public CryptaModel buildCryptaModel() {
+        return new CryptaModel(model, symbolsToVariables);
+    }
 
 }

--- a/src/main/java/cryptator/solver/AbstractModelerNodeConsumer.java
+++ b/src/main/java/cryptator/solver/AbstractModelerNodeConsumer.java
@@ -53,7 +53,7 @@ public abstract class AbstractModelerNodeConsumer implements ITraversalNodeConsu
 
     @Override
     public void accept(ICryptaNode node, int numNode) {
-        if (node.isLeaf() && !node.isConstant()) {
+        if (node.isWordLeaf()) {
             final char[] w = node.getWord();
             if (w.length > 0) firstSymbols.add(node.getWord()[0]);
         }

--- a/src/main/java/cryptator/solver/AdaptiveSolver.java
+++ b/src/main/java/cryptator/solver/AdaptiveSolver.java
@@ -8,70 +8,70 @@
  */
 package cryptator.solver;
 
-import java.util.function.Consumer;
-
-import org.chocosolver.solver.variables.IntVar;
-
 import cryptator.config.CryptaConfig;
 import cryptator.specs.ICryptaNode;
 import cryptator.specs.ICryptaSolution;
 import cryptator.specs.ICryptaSolver;
 import cryptator.specs.ITraversalNodeConsumer;
 import cryptator.tree.TreeTraversals;
+import org.chocosolver.solver.variables.IntVar;
+
+import java.util.function.Consumer;
 
 public class AdaptiveSolver implements ICryptaSolver {
 
-	public final CryptaSolver solver = new CryptaSolver();
+    public final CryptaSolver solver = new CryptaSolver();
 
-	public AdaptiveSolver() {
-		super();
-	}
+    public AdaptiveSolver() {
+        super();
+    }
 
-	public static int computeThreshold(int base) {
-		final int n = IntVar.MAX_INT_BOUND;
-		int prod = base; 
-		int i = 1;
-		while(prod < n) {
-			i++;
-			prod *= base;
-		}
-		return i;
-	}
-	@Override
-	public void limitTime(long limit) {
-		solver.limitTime(limit);
-	}
+    public static int computeThreshold(int base) {
+        final int n = IntVar.MAX_INT_BOUND;
+        int prod = base;
+        int i = 1;
+        while (prod < n) {
+            i++;
+            prod *= base;
+        }
+        return i;
+    }
 
-	@Override
-	public void limitSolution(long limit) {
-		solver.limitSolution(limit);
-	}
+    @Override
+    public void limitTime(long limit) {
+        solver.limitTime(limit);
+    }
 
-	@Override
-	public boolean solve(ICryptaNode cryptarithm, CryptaConfig config, Consumer<ICryptaSolution> solutionConsumer)
-			throws CryptaModelException, CryptaSolverException {
-		MaxLenConsumer cons = new MaxLenConsumer();
-		TreeTraversals.preorderTraversal(cryptarithm, cons);
-		final int threshold = computeThreshold(config.getArithmeticBase());
-		if(cons.getMaxLength() > threshold) solver.setBignum();
-		else solver.unsetBignum();
-		return solver.solve(cryptarithm, config, solutionConsumer);
-	}
+    @Override
+    public void limitSolution(long limit) {
+        solver.limitSolution(limit);
+    }
 
-	private static class MaxLenConsumer implements ITraversalNodeConsumer {
+    @Override
+    public boolean solve(ICryptaNode cryptarithm, CryptaConfig config, Consumer<ICryptaSolution> solutionConsumer)
+            throws CryptaModelException, CryptaSolverException {
+        MaxLenConsumer cons = new MaxLenConsumer();
+        TreeTraversals.preorderTraversal(cryptarithm, cons);
+        final int threshold = computeThreshold(config.getArithmeticBase());
+        if (cons.getMaxLength() > threshold) solver.setBignum();
+        else solver.unsetBignum();
+        return solver.solve(cryptarithm, config, solutionConsumer);
+    }
 
-		private int maxLen;
+    private static class MaxLenConsumer implements ITraversalNodeConsumer {
 
-		public final int getMaxLength() {
-			return maxLen;
-		}
+        private int maxLen;
 
-		@Override
-		public void accept(ICryptaNode node, int numNode) {
-			if(node.isLeaf()) {
-				final int len = node.getWord().length;
-				if(len > maxLen) maxLen = len;
-			}
-		}	
-	}
+        public final int getMaxLength() {
+            return maxLen;
+        }
+
+        @Override
+        public void accept(ICryptaNode node, int numNode) {
+            if (node.isLeaf() && !node.isConstant()) {
+                final int len = node.getWord().length;
+                if (len > maxLen) maxLen = len;
+            }
+        }
+    }
 }

--- a/src/main/java/cryptator/solver/AdaptiveSolver.java
+++ b/src/main/java/cryptator/solver/AdaptiveSolver.java
@@ -68,7 +68,7 @@ public class AdaptiveSolver implements ICryptaSolver {
 
         @Override
         public void accept(ICryptaNode node, int numNode) {
-            if (node.isLeaf() && !node.isConstant()) {
+            if (node.isWordLeaf()) {
                 final int len = node.getWord().length;
                 if (len > maxLen) maxLen = len;
             }

--- a/src/main/java/cryptator/solver/CryptaBignumModeler.java
+++ b/src/main/java/cryptator/solver/CryptaBignumModeler.java
@@ -8,13 +8,6 @@
  */
 package cryptator.solver;
 
-import java.util.ArrayDeque;
-import java.util.Deque;
-
-import org.chocosolver.solver.Model;
-import org.chocosolver.solver.expression.discrete.arithmetic.ArExpression;
-import org.chocosolver.solver.variables.IntVar;
-
 import cryptator.CryptaOperator;
 import cryptator.config.CryptaConfig;
 import cryptator.specs.ICryptaModeler;
@@ -23,6 +16,12 @@ import cryptator.tree.CryptaConstant;
 import cryptator.tree.CryptaOperatorDetection;
 import cryptator.tree.TreeTraversals;
 import cryptator.tree.TreeUtils;
+import org.chocosolver.solver.Model;
+import org.chocosolver.solver.expression.discrete.arithmetic.ArExpression;
+import org.chocosolver.solver.variables.IntVar;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
 
 public class CryptaBignumModeler implements ICryptaModeler {
 
@@ -102,8 +101,10 @@ final class ModelerBignumConsumer extends AbstractModelerNodeConsumer {
     @Override
     public void accept(ICryptaNode node, int numNode) {
         super.accept(node, numNode);
-        if (node.isLeaf()) {
-            stack.push(node instanceof CryptaConstant c ? makeConstantVars(c) : makeWordVars(node.getWord()));
+        if (node.isConstantLeaf()){
+            stack.push(makeConstantVars((CryptaConstant) node));
+        } else if (node.isWordLeaf()){
+            stack.push(makeWordVars(node.getWord()));
         } else if (!node.getOperator().equals(CryptaOperator.AND)) {
             final ArExpression[] b = stack.pop();
             final ArExpression[] a = stack.pop();

--- a/src/main/java/cryptator/solver/CryptaBignumModeler.java
+++ b/src/main/java/cryptator/solver/CryptaBignumModeler.java
@@ -8,15 +8,6 @@
  */
 package cryptator.solver;
 
-import java.util.ArrayDeque;
-import java.util.Arrays;
-import java.util.Deque;
-
-import org.chocosolver.solver.Model;
-import org.chocosolver.solver.expression.discrete.arithmetic.ArExpression;
-import org.chocosolver.solver.expression.discrete.relational.ReExpression;
-import org.chocosolver.solver.variables.IntVar;
-
 import cryptator.CryptaOperator;
 import cryptator.config.CryptaConfig;
 import cryptator.specs.ICryptaModeler;
@@ -24,136 +15,151 @@ import cryptator.specs.ICryptaNode;
 import cryptator.tree.CryptaOperatorDetection;
 import cryptator.tree.TreeTraversals;
 import cryptator.tree.TreeUtils;
+import org.chocosolver.solver.Model;
+import org.chocosolver.solver.expression.discrete.arithmetic.ArExpression;
+import org.chocosolver.solver.variables.IntVar;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
 
 public class CryptaBignumModeler implements ICryptaModeler {
 
-	/** bignum model with addition only that uses a little endian representation with a variable number of digits. */
-	@Override
-	public CryptaModel model(ICryptaNode cryptarithm, CryptaConfig config) throws CryptaModelException {
-		final CryptaOperatorDetection detect = TreeUtils.computeUnsupportedBignumOperator(cryptarithm);
-		if(detect.hasUnsupportedOperator()) throw new CryptaModelException("Unsupported bignum operator(s): " + detect.getUnsupportedOperator());
+    /**
+     * bignum model with addition only that uses a little endian representation with a variable number of digits.
+     */
+    @Override
+    public CryptaModel model(ICryptaNode cryptarithm, CryptaConfig config) throws CryptaModelException {
+        final CryptaOperatorDetection detect = TreeUtils.computeUnsupportedBignumOperator(cryptarithm);
+        if (detect.hasUnsupportedOperator())
+            throw new CryptaModelException("Unsupported bignum operator(s): " + detect.getUnsupportedOperator());
 
-		final Model model = new Model("Cryptarithm-bignum");
-		final AbstractModelerNodeConsumer modelerNodeConsumer = new ModelerBignumConsumer(model, config);
-		TreeTraversals.postorderTraversal(cryptarithm, modelerNodeConsumer);
-		modelerNodeConsumer.postConstraints();
-		return modelerNodeConsumer.buildCryptaModel();
-	}
+        final Model model = new Model("Cryptarithm-bignum");
+        final AbstractModelerNodeConsumer modelerNodeConsumer = new ModelerBignumConsumer(model, config);
+        TreeTraversals.postorderTraversal(cryptarithm, modelerNodeConsumer);
+        modelerNodeConsumer.postConstraints();
+        return modelerNodeConsumer.buildCryptaModel();
+    }
 }
 
 final class ModelerBignumConsumer extends AbstractModelerNodeConsumer {
 
-	private final Deque<ArExpression[]> stack = new ArrayDeque<>();
+    private final Deque<ArExpression[]> stack = new ArrayDeque<>();
 
-	public ModelerBignumConsumer(Model model, CryptaConfig config) {
-		super(model, config);
-	}
+    public ModelerBignumConsumer(Model model, CryptaConfig config) {
+        super(model, config);
+    }
 
-	private final ArExpression[] makeWordVars(char[] word) {
-		final int n = word.length;
-		// little endian
-		ArExpression[] vars = new ArExpression[n];
-		for (int i = 0; i < n; i++) {
-			vars[i] = getSymbolVar(word[n - 1 - i]);
-		}
-		return vars;
-	}
+    private ArExpression[] makeWordVars(char[] word) {
+        final int n = word.length;
+        // little endian
+        ArExpression[] vars = new ArExpression[n];
+        for (int i = 0; i < n; i++) {
+            vars[i] = getSymbolVar(word[n - 1 - i]);
+        }
+        return vars;
+    }
 
-
-	private final ArExpression[] applyADD(ArExpression[] a, ArExpression[] b) {
-		final int m = Math.min(a.length, b.length);
-		final int n = Math.max(a.length, b.length);
-		final ArExpression[] c = new ArExpression[n];
-		for (int i = 0; i < m; i++) {
-			c[i] = CryptaOperator.ADD.getExpression().apply(a[i], b[i]);
-		}
-		// Can only enter in one loop
-		for (int i = m; i < a.length; i++) {
-			c[i] = a[i];
-		}
-		for (int i = m; i < b.length; i++) {
-			c[i] = b[i];
-		}
-		return c;
-	}
-
-	class BignumArExpression {
-
-		public final IntVar[] digits;
-
-		public final IntVar[] carries;
-
-		public BignumArExpression(ArExpression[] a, int n, String suffix) {
-			super();
-			digits = model.intVarArray("D" + suffix, n, 0, config.getArithmeticBase()-1);
-			// TODO improve the bound ?
-			carries = model.intVarArray("C"+ suffix, n, 0, IntVar.MAX_INT_BOUND / config.getArithmeticBase());
-			postScalar(
-					new IntVar[] {carries[0], digits[0], a[0].intVar()},
-					new int[] {config.getArithmeticBase(), 1, -1}
-					);
-
-			for (int i = 1; i < a.length; i++) {
-				postScalar(
-						new IntVar[] {carries[i], digits[i], a[i].intVar(), carries[i-1]},
-						new int[] {config.getArithmeticBase(), 1, -1, -1}
-						);
-			}
-			for (int i = a.length; i < n; i++) {
-				postScalar(
-						new IntVar[] {carries[i], digits[i], carries[i-1]},
-						new int[] {config.getArithmeticBase(), 1, -1}
-						);
-			}
-		}
-
-		private void postScalar(IntVar[] vars, int[] coeffs) {
-			model.scalar(vars, coeffs, "=", 0).post();
-		}
-
-	}
+    private ArExpression[] makeConstantVars(char[] word) {
+        final int n = word.length;
+        // little endian
+        ArExpression[] vars = new ArExpression[n];
+        for (int i = 0; i < n; i++) {
+            vars[i] = model.intVar(Character.getNumericValue(word[n - 1 - i]));
+        }
+        return vars;
+    }
 
 
-	private final void applyEQ(ArExpression[] a, ArExpression[] b) {
-		int n = Math.max(a.length,  b.length);
-		BignumArExpression a1 = new BignumArExpression(a, n, "l");
-		BignumArExpression b1 = new BignumArExpression(b, n, "r");
-		for (int i = 0; i < n; i++) {
-			a1.digits[i].eq(b1.digits[i]).decompose().post();
-		}
-		a1.carries[n-1].eq(b1.carries[n-1]).decompose().post();
+    private ArExpression[] applyADD(ArExpression[] a, ArExpression[] b) {
+        final int m = Math.min(a.length, b.length);
+        final int n = Math.max(a.length, b.length);
+        final ArExpression[] c = new ArExpression[n];
+        for (int i = 0; i < m; i++) {
+            c[i] = CryptaOperator.ADD.getExpression().apply(a[i], b[i]);
+        }
+        // Can only enter in one loop
+        if (a.length - m >= 0) System.arraycopy(a, m, c, m, a.length - m);
+        System.arraycopy(b, m, c, m, b.length - m);
+        return c;
+    }
 
-	}
+    private void applyEQ(ArExpression[] a, ArExpression[] b) {
+        int n = Math.max(a.length, b.length);
+        BignumArExpression a1 = new BignumArExpression(a, n, "l");
+        BignumArExpression b1 = new BignumArExpression(b, n, "r");
+        for (int i = 0; i < n; i++) {
+            a1.digits[i].eq(b1.digits[i]).decompose().post();
+        }
+        a1.carries[n - 1].eq(b1.carries[n - 1]).decompose().post();
 
-	@Override
-	public void accept(ICryptaNode node, int numNode) {
-		super.accept(node, numNode);
-		if(node.isLeaf()) {
-			stack.push(makeWordVars(node.getWord()));
-		} else if (!node.getOperator().equals(CryptaOperator.AND)) {
-			final ArExpression[] b = stack.pop();
-			final ArExpression[] a = stack.pop();
-			switch (node.getOperator()) {
-			case ADD:
-				stack.push(applyADD(a, b));
-				break;
-			case EQ:
-				applyEQ(a, b);
-				if(!stack.isEmpty()) throw new IllegalStateException("Stack is not empty after accepting a relational operator."); 
-				break;
-			default:
-				//	Should never be in the default case, this exception is
-				//  a program break in order to recall to modify the switch if
-				//  a new operator in BigNum is added.
-				//  Example case : we remove the MUL operator in computeUnsupportedBignumOperator
-				throw new IllegalStateException("Bignum operator is not yet implemented");
-			}
-		}
-	}
+    }
 
-	@Override
-	public void postCryptarithmEquationConstraint() throws CryptaModelException {
-		if(!stack.isEmpty()) throw new CryptaModelException("Invalid stack size at the end of modeling.");
-	}
+    @Override
+    public void accept(ICryptaNode node, int numNode) {
+        super.accept(node, numNode);
+        if (node.isLeaf()) {
+            stack.push(node.isConstant() ? makeConstantVars(node.getWord()) : makeWordVars(node.getWord()));
+        } else if (!node.getOperator().equals(CryptaOperator.AND)) {
+            final ArExpression[] b = stack.pop();
+            final ArExpression[] a = stack.pop();
+            switch (node.getOperator()) {
+                case ADD:
+                    stack.push(applyADD(a, b));
+                    break;
+                case EQ:
+                    applyEQ(a, b);
+                    if (!stack.isEmpty())
+                        throw new IllegalStateException("Stack is not empty after accepting a relational operator.");
+                    break;
+                default:
+                    //	Should never be in the default case, this exception is
+                    //  a program break in order to recall to modify the switch if
+                    //  a new operator in BigNum is added.
+                    //  Example case : we remove the MUL operator in computeUnsupportedBignumOperator
+                    throw new IllegalStateException("Bignum operator is not yet implemented");
+            }
+        }
+    }
+
+    @Override
+    public void postCryptarithmEquationConstraint() throws CryptaModelException {
+        if (!stack.isEmpty()) throw new CryptaModelException("Invalid stack size at the end of modeling.");
+    }
+
+    class BignumArExpression {
+
+        public final IntVar[] digits;
+
+        public final IntVar[] carries;
+
+        public BignumArExpression(ArExpression[] a, int n, String suffix) {
+            super();
+            digits = model.intVarArray("D" + suffix, n, 0, config.getArithmeticBase() - 1);
+            // TODO improve the bound ?
+            carries = model.intVarArray("C" + suffix, n, 0, IntVar.MAX_INT_BOUND / config.getArithmeticBase());
+            postScalar(
+                    new IntVar[]{carries[0], digits[0], a[0].intVar()},
+                    new int[]{config.getArithmeticBase(), 1, -1}
+            );
+
+            for (int i = 1; i < a.length; i++) {
+                postScalar(
+                        new IntVar[]{carries[i], digits[i], a[i].intVar(), carries[i - 1]},
+                        new int[]{config.getArithmeticBase(), 1, -1, -1}
+                );
+            }
+            for (int i = a.length; i < n; i++) {
+                postScalar(
+                        new IntVar[]{carries[i], digits[i], carries[i - 1]},
+                        new int[]{config.getArithmeticBase(), 1, -1}
+                );
+            }
+        }
+
+        private void postScalar(IntVar[] vars, int[] coeffs) {
+            model.scalar(vars, coeffs, "=", 0).post();
+        }
+
+    }
 
 }

--- a/src/main/java/cryptator/solver/CryptaModeler.java
+++ b/src/main/java/cryptator/solver/CryptaModeler.java
@@ -8,19 +8,20 @@
  */
 package cryptator.solver;
 
-import cryptator.config.CryptaConfig;
-import cryptator.specs.ICryptaModeler;
-import cryptator.specs.ICryptaNode;
-import cryptator.tree.CryptaConstant;
-import cryptator.tree.TreeTraversals;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.function.Function;
+
 import org.chocosolver.solver.Model;
 import org.chocosolver.solver.expression.discrete.arithmetic.ArExpression;
 import org.chocosolver.solver.expression.discrete.relational.ReExpression;
 import org.chocosolver.solver.variables.IntVar;
 
-import java.util.ArrayDeque;
-import java.util.Deque;
-import java.util.function.Function;
+import cryptator.config.CryptaConfig;
+import cryptator.specs.ICryptaModeler;
+import cryptator.specs.ICryptaNode;
+import cryptator.tree.CryptaConstant;
+import cryptator.tree.TreeTraversals;
 
 public class CryptaModeler implements ICryptaModeler {
 
@@ -66,7 +67,6 @@ final class ModelerConsumer extends AbstractModelerNodeConsumer {
 
     @Override
     public void postCryptarithmEquationConstraint() throws CryptaModelException {
-//		TODO : modify here !!
         if (stack.size() != 1) throw new CryptaModelException("Invalid stack size at the end of modeling.");
         if (stack.peek() instanceof ReExpression) {
             ((ReExpression) stack.peek()).decompose().post();

--- a/src/main/java/cryptator/solver/CryptaModeler.java
+++ b/src/main/java/cryptator/solver/CryptaModeler.java
@@ -11,6 +11,7 @@ package cryptator.solver;
 import cryptator.config.CryptaConfig;
 import cryptator.specs.ICryptaModeler;
 import cryptator.specs.ICryptaNode;
+import cryptator.tree.CryptaConstant;
 import cryptator.tree.TreeTraversals;
 import org.chocosolver.solver.Model;
 import org.chocosolver.solver.expression.discrete.arithmetic.ArExpression;
@@ -53,7 +54,9 @@ final class ModelerConsumer extends AbstractModelerNodeConsumer {
     public void accept(ICryptaNode node, int numNode) {
         super.accept(node, numNode);
         if (node.isLeaf()) {
-            stack.push(makeWordVar(node.getWord()));
+            stack.push(node instanceof CryptaConstant constant ?
+                    model.intVar(constant.getConstant()) :
+                    makeWordVar(node.getWord()));
         } else {
             final ArExpression b = stack.pop();
             final ArExpression a = stack.pop();

--- a/src/main/java/cryptator/solver/CryptaModeler.java
+++ b/src/main/java/cryptator/solver/CryptaModeler.java
@@ -8,20 +8,19 @@
  */
 package cryptator.solver;
 
-import java.util.ArrayDeque;
-import java.util.Deque;
-import java.util.function.Function;
-
-import org.chocosolver.solver.Model;
-import org.chocosolver.solver.expression.discrete.arithmetic.ArExpression;
-import org.chocosolver.solver.expression.discrete.relational.ReExpression;
-import org.chocosolver.solver.variables.IntVar;
-
 import cryptator.config.CryptaConfig;
 import cryptator.specs.ICryptaModeler;
 import cryptator.specs.ICryptaNode;
 import cryptator.tree.CryptaConstant;
 import cryptator.tree.TreeTraversals;
+import org.chocosolver.solver.Model;
+import org.chocosolver.solver.expression.discrete.arithmetic.ArExpression;
+import org.chocosolver.solver.expression.discrete.relational.ReExpression;
+import org.chocosolver.solver.variables.IntVar;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.function.Function;
 
 public class CryptaModeler implements ICryptaModeler {
 
@@ -54,10 +53,10 @@ final class ModelerConsumer extends AbstractModelerNodeConsumer {
     @Override
     public void accept(ICryptaNode node, int numNode) {
         super.accept(node, numNode);
-        if (node.isLeaf()) {
-            stack.push(node instanceof CryptaConstant constant ?
-                    model.intVar(constant.getConstant()) :
-                    makeWordVar(node.getWord()));
+        if (node.isConstantLeaf()) {
+            stack.push(model.intVar(((CryptaConstant) node).getConstant()));
+        } else if (node.isWordLeaf()) {
+            stack.push(makeWordVar(node.getWord()));
         } else {
             final ArExpression b = stack.pop();
             final ArExpression a = stack.pop();

--- a/src/main/java/cryptator/solver/CryptaSolutionMap.java
+++ b/src/main/java/cryptator/solver/CryptaSolutionMap.java
@@ -8,57 +8,57 @@
  */
 package cryptator.solver;
 
+import cryptator.specs.ICryptaSolution;
+
 import java.util.HashMap;
 import java.util.Map;
 
-import cryptator.specs.ICryptaSolution;
-
 public class CryptaSolutionMap extends AbstractCryptaSolution<Integer> {
 
-			
-	public static final ICryptaSolution parseSolution(String solution) throws CryptaSolutionException {
-		final HashMap<Character, Integer> symbolToDigit = new HashMap<>();
-		final String[] split = solution.split("\\s*[\\s=]\\s*");
-		//System.out.println(Arrays.toString(split));
-		if( split.length % 2 != 0) throw new CryptaSolutionException("Invalid number of splits: " + split.length);
-		for (int i = 0; i < split.length; i+=2) {
-			if( split[i].length() != 1) throw new CryptaSolutionException("Invalid symbol: " + split[i]);
-			final char symbol = split[i].charAt(0);
-			try {
-				final int digit = Integer.parseInt(split[i+1]);
-				symbolToDigit.put(symbol, digit);
-			} catch (NumberFormatException e) {
-				throw new CryptaSolutionException("Invalid digit: " + split[i+1]);
-			}
-		}
-		return new CryptaSolutionMap(symbolToDigit);
-	}
-	
-	protected CryptaSolutionMap(Map<Character, Integer> symbolsToDigits) {
-		super(symbolsToDigits);
-	}
-	
-	@Override
-	public boolean hasDigit(char symbol) {
-		return symbolsToDigits.containsKey(symbol);
-	}
 
-	@Override
-	public int getDigit(char symbol) throws CryptaSolutionException {
-		final Integer v = symbolsToDigits.get(symbol);
-		if( v == null ) throw new CryptaSolutionException("cant find symbol: " + symbol);
-		else return v;
-	}
+    protected CryptaSolutionMap(Map<Character, Integer> symbolsToDigits) {
+        super(symbolsToDigits);
+    }
 
-	@Override
-	public int getDigit(char symbol, int defaultValue) {
-		return symbolsToDigits.getOrDefault(symbol, defaultValue);
-	}
-	
-	@Override
-	protected String getDomain(Integer v) {
-		return v.toString();
-	}
+    public static final ICryptaSolution parseSolution(String solution) throws CryptaSolutionException {
+        final HashMap<Character, Integer> symbolToDigit = new HashMap<>();
+        final String[] split = solution.split("\\s*[\\s=]\\s*");
+        //System.out.println(Arrays.toString(split));
+        if (split.length % 2 != 0) throw new CryptaSolutionException("Invalid number of splits: " + split.length);
+        for (int i = 0; i < split.length; i += 2) {
+            if (split[i].length() != 1) throw new CryptaSolutionException("Invalid symbol: " + split[i]);
+            final char symbol = split[i].charAt(0);
+            try {
+                final int digit = Integer.parseInt(split[i + 1]);
+                symbolToDigit.put(symbol, digit);
+            } catch (NumberFormatException e) {
+                throw new CryptaSolutionException("Invalid digit: " + split[i + 1]);
+            }
+        }
+        return new CryptaSolutionMap(symbolToDigit);
+    }
 
-	
+    @Override
+    public boolean hasDigit(char symbol) {
+        return symbolsToDigits.containsKey(symbol);
+    }
+
+    @Override
+    public int getDigit(char symbol) throws CryptaSolutionException {
+        final Integer v = symbolsToDigits.get(symbol);
+        if (v == null) throw new CryptaSolutionException("cant find symbol: " + symbol);
+        else return v;
+    }
+
+    @Override
+    public int getDigit(char symbol, int defaultValue) {
+        return symbolsToDigits.getOrDefault(symbol, defaultValue);
+    }
+
+    @Override
+    protected String getDomain(Integer v) {
+        return v.toString();
+    }
+
+
 }

--- a/src/main/java/cryptator/specs/ICryptaNode.java
+++ b/src/main/java/cryptator/specs/ICryptaNode.java
@@ -14,7 +14,7 @@ import cryptator.CryptaOperator;
  * The Interface ICryptaNode defines a node of an abstract syntax binary tree that represents a cryptarithm.
  * The tree is not the parse tree built by the ANTLR parser.
  * Each node, even a leaf, is associated to an operator and to a word.
- * 
+ *
  */
 public interface ICryptaNode {
 
@@ -24,14 +24,14 @@ public interface ICryptaNode {
 	 * @return the operator
 	 */
 	CryptaOperator getOperator();
-	
+
 	/**
 	 * Gets the word associated to the node.
 	 *
 	 * @return the word
 	 */
 	char[] getWord();
-	
+
 	/**
 	 * Gets the left child if any.
 	 *
@@ -39,7 +39,7 @@ public interface ICryptaNode {
 	 */
 	ICryptaNode getLeftChild();
 	//FIXME Use java.util.Optional ? 
-	
+
 	/**
 	 * Gets the right child if any.
 	 *
@@ -47,19 +47,21 @@ public interface ICryptaNode {
 	 */
 	ICryptaNode getRightChild();
 	//FIXME Use java.util.Optional ? 
-	
+
 	/**
 	 * Checks if the node is a leaf of the tree.
 	 *
 	 * @return true, if it is leaf
 	 */
 	boolean isLeaf();
-	
+
 	/**
 	 * Checks if the node is an internal node of the tree.
 	 *
 	 * @return true, if it is internal node
 	 */
 	boolean isInternalNode();
-	
+
+	boolean isConstant();
+
 }

--- a/src/main/java/cryptator/specs/ICryptaNode.java
+++ b/src/main/java/cryptator/specs/ICryptaNode.java
@@ -69,4 +69,12 @@ public interface ICryptaNode {
      * @return true, if it is internal node
      */
     boolean isInternalNode();
+
+    /**
+     * Transform parsed node to string.
+     * For example parse(inOrderPrint(parse("a+'8'=b"))) is the same as parse("a+'8'=b")
+     *
+     * @return the string representation of the node accepted by the parser
+     */
+    String write();
 }

--- a/src/main/java/cryptator/specs/ICryptaNode.java
+++ b/src/main/java/cryptator/specs/ICryptaNode.java
@@ -11,57 +11,62 @@ package cryptator.specs;
 import cryptator.CryptaOperator;
 
 /**
- * The Interface ICryptaNode defines a node of an abstract syntax binary tree that represents a cryptarithm.
- * The tree is not the parse tree built by the ANTLR parser.
- * Each node, even a leaf, is associated to an operator and to a word.
+ * The Interface ICryptaNode defines a node of an abstract syntax binary tree
+ * that represents a cryptarithm. The tree is not the parse tree built by the
+ * ANTLR parser. Each node, even a leaf, is associated to an operator and to a
+ * word.
  *
  */
 public interface ICryptaNode {
 
-	/**
-	 * Gets the binary operator associated to the node.
-	 *
-	 * @return the operator
-	 */
-	CryptaOperator getOperator();
+    /**
+     * Gets the binary operator associated to the node.
+     *
+     * @return the operator
+     */
+    CryptaOperator getOperator();
 
-	/**
-	 * Gets the word associated to the node.
-	 *
-	 * @return the word
-	 */
-	char[] getWord();
+    /**
+     * Gets the word associated to the node.
+     *
+     * @return the word
+     */
+    char[] getWord();
 
-	/**
-	 * Gets the left child if any.
-	 *
-	 * @return the left child
-	 */
-	ICryptaNode getLeftChild();
-	//FIXME Use java.util.Optional ? 
+    /**
+     * Gets the left child if any.
+     *
+     * @return the left child
+     */
+    ICryptaNode getLeftChild();
+    // FIXME Use java.util.Optional ?
 
-	/**
-	 * Gets the right child if any.
-	 *
-	 * @return the right child
-	 */
-	ICryptaNode getRightChild();
-	//FIXME Use java.util.Optional ? 
+    /**
+     * Gets the right child if any.
+     *
+     * @return the right child
+     */
+    ICryptaNode getRightChild();
+    // FIXME Use java.util.Optional ?
 
-	/**
-	 * Checks if the node is a leaf of the tree.
-	 *
-	 * @return true, if it is leaf
-	 */
-	boolean isLeaf();
+    /**
+     * Checks if the node is a constant leaf of the tree.
+     *
+     * @return true, if it is a constant leaf
+     */
+    boolean isConstantLeaf();
 
-	/**
-	 * Checks if the node is an internal node of the tree.
-	 *
-	 * @return true, if it is internal node
-	 */
-	boolean isInternalNode();
+    /**
+     * Checks if the node is a word leaf of the tree.
+     *
+     * @return true, if it is a word leaf
+     */
+    boolean isWordLeaf();
 
-	boolean isConstant();
-
+    /**
+     * Checks if the node is an internal node of the tree.
+     *
+     * @return true, if it is internal node
+     */
+    boolean isInternalNode();
 }

--- a/src/main/java/cryptator/tree/CryptaConstant.java
+++ b/src/main/java/cryptator/tree/CryptaConstant.java
@@ -1,0 +1,29 @@
+/**
+ * This file is part of cryptator, https://github.com/arnaud-m/cryptator
+ *
+ * Copyright (c) 2022, Université Côte d'Azur. All rights reserved.
+ *
+ * Licensed under the BSD 3-clause license.
+ * See LICENSE file in the project root for full license information.
+ */
+package cryptator.tree;
+
+public class CryptaConstant extends CryptaLeaf {
+    public CryptaConstant() {
+        this(new char[0]);
+    }
+
+    public CryptaConstant(String word) {
+        this(word.toCharArray());
+    }
+
+    public CryptaConstant(char[] word) {
+        super(word, true);
+    }
+
+
+    // TODO : convert to base of cryptarithm
+    public int getConstant() {
+        return Integer.parseInt(new String(getWord()));
+    }
+}

--- a/src/main/java/cryptator/tree/CryptaConstant.java
+++ b/src/main/java/cryptator/tree/CryptaConstant.java
@@ -9,21 +9,25 @@
 package cryptator.tree;
 
 public class CryptaConstant extends CryptaLeaf {
-    public CryptaConstant() {
-        this(new char[0]);
-    }
+	public CryptaConstant() {
+		super();
+	}
 
-    public CryptaConstant(String word) {
-        this(word.toCharArray());
-    }
+	public CryptaConstant(String word) {
+		super(word);
+	}
 
-    public CryptaConstant(char[] word) {
-        super(word, true);
-    }
+	public CryptaConstant(char[] word) {
+		super(word);
+	}
 
+	@Override
+	public boolean isConstant() {
+		return true;
+	}
 
-    // TODO : convert to base of cryptarithm
-    public int getConstant() {
-        return Integer.parseInt(new String(getWord()));
-    }
+	// TODO : convert to base of cryptarithm
+	public int getConstant() {
+		return Integer.parseInt(new String(getWord()));
+	}
 }

--- a/src/main/java/cryptator/tree/CryptaConstant.java
+++ b/src/main/java/cryptator/tree/CryptaConstant.java
@@ -62,4 +62,9 @@ public class CryptaConstant extends CryptaLeaf {
 		}
 		return newInt.toArray(new Integer[0]);
 	}
+
+	@Override
+	public String write(){
+		return "'" + constant + "'";
+	}
 }

--- a/src/main/java/cryptator/tree/CryptaConstant.java
+++ b/src/main/java/cryptator/tree/CryptaConstant.java
@@ -30,8 +30,13 @@ public class CryptaConstant extends CryptaLeaf {
 	}
 
 	@Override
-	public boolean isConstant() {
+	public boolean isConstantLeaf() {
 		return true;
+	}
+
+	@Override
+	public boolean isWordLeaf() {
+		return false;
 	}
 
 	public int getConstant() {

--- a/src/main/java/cryptator/tree/CryptaConstant.java
+++ b/src/main/java/cryptator/tree/CryptaConstant.java
@@ -8,17 +8,25 @@
  */
 package cryptator.tree;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class CryptaConstant extends CryptaLeaf {
+	public static final int DEFAULT_BASE = 10;
+	private final int constant;
 	public CryptaConstant() {
 		super();
+		constant = Integer.parseInt(new String(getWord()));
 	}
 
 	public CryptaConstant(String word) {
 		super(word);
+		constant = Integer.parseInt(new String(getWord()));
 	}
 
 	public CryptaConstant(char[] word) {
 		super(word);
+		constant = Integer.parseInt(new String(getWord()));
 	}
 
 	@Override
@@ -26,8 +34,27 @@ public class CryptaConstant extends CryptaLeaf {
 		return true;
 	}
 
-	// TODO : convert to base of cryptarithm
 	public int getConstant() {
-		return Integer.parseInt(new String(getWord()));
+		return constant;
+	}
+
+	/**
+	 * @param newBase : the new base to which convert the current constant (Note the current constant is by default in base 10)
+	 * @return an Integer[] of the little representation of the int in the newBase
+	 *
+	 * For example, the constant 178829 will be res = [13, 8, 10, 11, 2] since
+	 * sum_{i from 0 to newBase - 1} res[i] * newBase^i = 178829
+	 */
+	public Integer[] changeBaseLittleEndian(int newBase){
+		var length = getWord().length;
+		List<Integer> newInt = new ArrayList<>();
+		var n = this.constant;
+		while (n > 0){
+			var reminder = n % newBase;
+			var divRes = n / newBase;
+			newInt.add(reminder);
+			n = divRes;
+		}
+		return newInt.toArray(new Integer[0]);
 	}
 }

--- a/src/main/java/cryptator/tree/CryptaEvaluation.java
+++ b/src/main/java/cryptator/tree/CryptaEvaluation.java
@@ -65,7 +65,7 @@ public class CryptaEvaluation implements ICryptaEvaluation {
         public void accept(ICryptaNode node, int numNode) {
             // Check for the exception because it cannot be thrown here.
             if (exception == null) {
-                if (node.isLeaf()) {
+                if (node.isWordLeaf() || node.isConstantLeaf()) {
                     try {
                         stack.push(getWordValue(node));
                     } catch (CryptaEvaluationException e) {

--- a/src/main/java/cryptator/tree/CryptaEvaluation.java
+++ b/src/main/java/cryptator/tree/CryptaEvaluation.java
@@ -8,81 +8,84 @@
  */
 package cryptator.tree;
 
-import java.math.BigInteger;
-import java.util.ArrayDeque;
-import java.util.Deque;
-
 import cryptator.solver.CryptaSolutionException;
 import cryptator.specs.ICryptaEvaluation;
 import cryptator.specs.ICryptaNode;
 import cryptator.specs.ICryptaSolution;
 import cryptator.specs.ITraversalNodeConsumer;
 
+import java.math.BigInteger;
+import java.util.ArrayDeque;
+import java.util.Deque;
+
 public class CryptaEvaluation implements ICryptaEvaluation {
 
-	@Override
-	public BigInteger evaluate(ICryptaNode cryptarithm, ICryptaSolution solution, int base) throws CryptaEvaluationException {
-		final EvaluationConsumer evaluationNodeConsumer = new EvaluationConsumer(solution, base);
-		TreeTraversals.postorderTraversal(cryptarithm, evaluationNodeConsumer);
-		return evaluationNodeConsumer.eval();
-	}	
+    @Override
+    public BigInteger evaluate(ICryptaNode cryptarithm, ICryptaSolution solution, int base) throws CryptaEvaluationException {
+        final EvaluationConsumer evaluationNodeConsumer = new EvaluationConsumer(solution, base);
+        TreeTraversals.postorderTraversal(cryptarithm, evaluationNodeConsumer);
+        return evaluationNodeConsumer.eval();
+    }
 
-	private static class EvaluationConsumer implements ITraversalNodeConsumer {
+    private static class EvaluationConsumer implements ITraversalNodeConsumer {
 
-		private final ICryptaSolution solution;
+        private final ICryptaSolution solution;
 
-		private final int base;
+        private final int base;
 
-		private final Deque<BigInteger> stack = new ArrayDeque<>();
+        private final Deque<BigInteger> stack = new ArrayDeque<>();
 
-		private CryptaEvaluationException exception;
+        private CryptaEvaluationException exception;
 
-		public EvaluationConsumer(ICryptaSolution solution, int base) {
-			super();
-			this.solution = solution;
-			this.base = base;
-		}
+        public EvaluationConsumer(ICryptaSolution solution, int base) {
+            super();
+            this.solution = solution;
+            this.base = base;
+        }
 
-		private BigInteger getWordValue(ICryptaNode node) throws CryptaEvaluationException {
-			try {
-				BigInteger v = BigInteger.ZERO;
-				final BigInteger b = BigInteger.valueOf(base);
-				for (char c : node.getWord()) {
-					final int digit = solution.getDigit(c);
-					if(digit < 0 || digit >= base) throw new CryptaEvaluationException("cannot evaluate because of an invalid digit for the evaluation base.");
-					v = v.multiply(b).add(BigInteger.valueOf(digit));
-				}
-				return v;
-			} catch (CryptaSolutionException e) {
-				throw new CryptaEvaluationException("Cannot use a partial solution for evaluation", e);
-			}
-		}
+        private BigInteger getWordValue(ICryptaNode node) throws CryptaEvaluationException {
+            try {
+                BigInteger v = BigInteger.ZERO;
+                final BigInteger b = BigInteger.valueOf(base);
+                if (node instanceof CryptaConstant constant)
+                    return BigInteger.valueOf(constant.getConstant());
+                for (char c : node.getWord()) {
+                    final int digit = solution.getDigit(c);
+                    if (digit < 0 || digit >= base)
+                        throw new CryptaEvaluationException("cannot evaluate because of an invalid digit for the evaluation base.");
+                    v = v.multiply(b).add(BigInteger.valueOf(digit));
+                }
+                return v;
+            } catch (CryptaSolutionException e) {
+                throw new CryptaEvaluationException("Cannot use a partial solution for evaluation", e);
+            }
+        }
 
-		@Override
-		public void accept(ICryptaNode node, int numNode) {
-			// Check for the exception because it cannot be thrown here.
-			if(exception == null) {
-				if(node.isLeaf()) {
-					try {
-						stack.push(getWordValue(node));
-					} catch (CryptaEvaluationException e) {
-						exception = e;
-					}
-				} else {
-					final BigInteger b = stack.pop();
-					final BigInteger a = stack.pop();
-					// System.out.println(a+ " " + b);
-					stack.push(node.getOperator().getFunction().apply(a, b));
-				}
-			}
-		}
+        @Override
+        public void accept(ICryptaNode node, int numNode) {
+            // Check for the exception because it cannot be thrown here.
+            if (exception == null) {
+                if (node.isLeaf()) {
+                    try {
+                        stack.push(getWordValue(node));
+                    } catch (CryptaEvaluationException e) {
+                        exception = e;
+                    }
+                } else {
+                    final BigInteger b = stack.pop();
+                    final BigInteger a = stack.pop();
+                    // System.out.println(a+ " " + b);
+                    stack.push(node.getOperator().getFunction().apply(a, b));
+                }
+            }
+        }
 
 
-		public BigInteger eval() throws CryptaEvaluationException {
-			if(exception != null) throw exception;
-			if(stack.size() != 1) throw new CryptaEvaluationException("Invalid stack size at the end of evaluation.");
-			return new BigInteger(stack.peek().toString());
-		}
-	}
+        public BigInteger eval() throws CryptaEvaluationException {
+            if (exception != null) throw exception;
+            if (stack.size() != 1) throw new CryptaEvaluationException("Invalid stack size at the end of evaluation.");
+            return new BigInteger(stack.peek().toString());
+        }
+    }
 
 }

--- a/src/main/java/cryptator/tree/CryptaFeatures.java
+++ b/src/main/java/cryptator/tree/CryptaFeatures.java
@@ -39,7 +39,7 @@ public class CryptaFeatures implements ITraversalNodeConsumer {
 		if (node.isConstantLeaf()){
 			constantCount++;
 			constants.add(((CryptaConstant) node).getConstant());
-		} else if(node.isConstantLeaf() || node.isWordLeaf()) {
+		} else if(node.isWordLeaf()) {
 			final char[] word = node.getWord();
 			final int n = word.length;
 			if(n > 0) {

--- a/src/main/java/cryptator/tree/CryptaFeatures.java
+++ b/src/main/java/cryptator/tree/CryptaFeatures.java
@@ -8,36 +8,38 @@
  */
 package cryptator.tree;
 
+import cryptator.CryptaOperator;
+import cryptator.specs.ICryptaNode;
+import cryptator.specs.ITraversalNodeConsumer;
+
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import cryptator.CryptaOperator;
-import cryptator.specs.ICryptaNode;
-import cryptator.specs.ITraversalNodeConsumer;
-
 public class CryptaFeatures implements ITraversalNodeConsumer {
 
+	private int constantCount = 0;
 	private int wordCount;
-	
 	private int charCount;
-	
 	private int minWordLength = Integer.MAX_VALUE;
-	
 	private int maxWordLength;
-	
 	private Set<Character> symbols = new HashSet<>();
-	
+
+	private Set<Integer> constants = new HashSet<>();
+
 	private Set<CryptaOperator> operators = new HashSet<>();
-	
+
 	public CryptaFeatures() {
 		super();
 	}
-	
+
 	@Override
 	public void accept(ICryptaNode node, int numNode) {
-		if(node.isLeaf()) {
+		if (node.isConstantLeaf()){
+			constantCount++;
+			constants.add(((CryptaConstant) node).getConstant());
+		} else if(node.isConstantLeaf() || node.isWordLeaf()) {
 			final char[] word = node.getWord();
 			final int n = word.length;
 			if(n > 0) {
@@ -62,6 +64,10 @@ public class CryptaFeatures implements ITraversalNodeConsumer {
 		return charCount;
 	}
 
+	public int getConstantCount() {
+		return constantCount;
+	}
+
 	public final int getMinWordLength() {
 		return minWordLength;
 	}
@@ -74,10 +80,14 @@ public class CryptaFeatures implements ITraversalNodeConsumer {
 		return Collections.unmodifiableSet(symbols);
 	}
 
+	public Set<Integer> getConstants() {
+		return constants;
+	}
+
 	public final Set<CryptaOperator> getOperators() {
 		return Collections.unmodifiableSet(operators);
 	}
-	
+
 	@Override
 	public String toString() {
 		StringBuilder b = new StringBuilder();
@@ -88,7 +98,7 @@ public class CryptaFeatures implements ITraversalNodeConsumer {
 		b.append("\nc MIN_WORD_LEN ").append(minWordLength);
 		b.append("\nc MAX_WORD_LEN ").append(maxWordLength);
 		b.append("\nc SYMBOLS ").append(symbols.stream().map(String::valueOf).collect(Collectors.joining()));
-		b.append("\nc OPERATORS ").append(operators.stream().map(String::valueOf).collect(Collectors.joining(" ", "", "")));	
+		b.append("\nc OPERATORS ").append(operators.stream().map(String::valueOf).collect(Collectors.joining(" ", "", "")));
 		return b.toString();
 	}
 

--- a/src/main/java/cryptator/tree/CryptaLeaf.java
+++ b/src/main/java/cryptator/tree/CryptaLeaf.java
@@ -66,4 +66,9 @@ public class CryptaLeaf implements ICryptaNode {
 	public String toString() {
 		return new String(word);
 	}
+
+	@Override
+	public String write(){
+		return new String(getWord());
+	}
 }

--- a/src/main/java/cryptator/tree/CryptaLeaf.java
+++ b/src/main/java/cryptator/tree/CryptaLeaf.java
@@ -13,52 +13,67 @@ import cryptator.specs.ICryptaNode;
 
 public class CryptaLeaf implements ICryptaNode {
 
-	private final char[] word;
-	
-	public CryptaLeaf() {
-		this(new char[0]);
-	}
-	
-	public CryptaLeaf(String word) {
-		this(word.toCharArray());
-	}
-	
-	public CryptaLeaf(char[] word) {
-		this.word = word;
-	}
-	
-	@Override
-	public CryptaOperator getOperator() {
-		return CryptaOperator.ID;
-	}
+    private final char[] word;
+    private final boolean isConstant;
 
-	@Override
-	public char[] getWord() {
-		return word;
-	}
+    public CryptaLeaf() {
+        this(new char[0]);
+    }
 
-	@Override
-	public ICryptaNode getLeftChild() {
-		return null;
-	}
+    public CryptaLeaf(String word) {
+        this(word.toCharArray());
+    }
 
-	@Override
-	public ICryptaNode getRightChild() {
-		return null;
-	}
+    public CryptaLeaf(String word, boolean isConstant) {
+        this(word.toCharArray(), isConstant);
+    }
 
-	@Override
-	public boolean isLeaf() {
-		return true;
-	}
+    public CryptaLeaf(char[] word) {
+        this(word, false);
+    }
 
-	@Override
-	public boolean isInternalNode() {
-		return false;
-	}
-	
-	@Override
-	public String toString() {
-		return new String(word);
-	}
+    public CryptaLeaf(char[] word, boolean isConstant) {
+        this.word = word;
+        this.isConstant = isConstant;
+    }
+
+    @Override
+    public CryptaOperator getOperator() {
+        return CryptaOperator.ID;
+    }
+
+    @Override
+    public char[] getWord() {
+        return word;
+    }
+
+    @Override
+    public ICryptaNode getLeftChild() {
+        return null;
+    }
+
+    @Override
+    public ICryptaNode getRightChild() {
+        return null;
+    }
+
+    @Override
+    public boolean isLeaf() {
+        return true;
+    }
+
+    @Override
+    public boolean isConstant() {
+        return isConstant;
+    }
+
+    @Override
+    public boolean isInternalNode() {
+        return false;
+    }
+
+    @Override
+    public String toString() {
+        return new String(word);
+    }
 }

--- a/src/main/java/cryptator/tree/CryptaLeaf.java
+++ b/src/main/java/cryptator/tree/CryptaLeaf.java
@@ -13,63 +13,57 @@ import cryptator.specs.ICryptaNode;
 
 public class CryptaLeaf implements ICryptaNode {
 
-    private final char[] word;
-    private final boolean isConstant;
+	private final char[] word;
 
-    public CryptaLeaf() {
-        this(new char[0]);
-    }
+	public CryptaLeaf() {
+		this(new char[0]);
+	}
 
-    public CryptaLeaf(String word) {
-        this(word.toCharArray());
-    }
+	public CryptaLeaf(String word) {
+		this(word.toCharArray());
+	}
 
-    public CryptaLeaf(char[] word) {
-        this(word, false);
-    }
+	public CryptaLeaf(char[] word) {
+		this.word = word;
+	}
 
-    public CryptaLeaf(char[] word, boolean isConstant) {
-        this.word = word;
-        this.isConstant = isConstant;
-    }
+	@Override
+	public CryptaOperator getOperator() {
+		return CryptaOperator.ID;
+	}
 
-    @Override
-    public CryptaOperator getOperator() {
-        return CryptaOperator.ID;
-    }
+	@Override
+	public char[] getWord() {
+		return word;
+	}
 
-    @Override
-    public char[] getWord() {
-        return word;
-    }
+	@Override
+	public ICryptaNode getLeftChild() {
+		return null;
+	}
 
-    @Override
-    public ICryptaNode getLeftChild() {
-        return null;
-    }
+	@Override
+	public ICryptaNode getRightChild() {
+		return null;
+	}
 
-    @Override
-    public ICryptaNode getRightChild() {
-        return null;
-    }
+	@Override
+	public boolean isLeaf() {
+		return true;
+	}
 
-    @Override
-    public boolean isLeaf() {
-        return true;
-    }
+	@Override
+	public boolean isConstant() {
+		return false;
+	}
 
-    @Override
-    public boolean isConstant() {
-        return isConstant;
-    }
+	@Override
+	public boolean isInternalNode() {
+		return false;
+	}
 
-    @Override
-    public boolean isInternalNode() {
-        return false;
-    }
-
-    @Override
-    public String toString() {
-        return new String(word);
-    }
+	@Override
+	public String toString() {
+		return new String(word);
+	}
 }

--- a/src/main/java/cryptator/tree/CryptaLeaf.java
+++ b/src/main/java/cryptator/tree/CryptaLeaf.java
@@ -48,13 +48,13 @@ public class CryptaLeaf implements ICryptaNode {
 	}
 
 	@Override
-	public boolean isLeaf() {
-		return true;
+	public boolean isConstantLeaf() {
+		return false;
 	}
 
 	@Override
-	public boolean isConstant() {
-		return false;
+	public boolean isWordLeaf() {
+		return true;
 	}
 
 	@Override

--- a/src/main/java/cryptator/tree/CryptaLeaf.java
+++ b/src/main/java/cryptator/tree/CryptaLeaf.java
@@ -24,10 +24,6 @@ public class CryptaLeaf implements ICryptaNode {
         this(word.toCharArray());
     }
 
-    public CryptaLeaf(String word, boolean isConstant) {
-        this(word.toCharArray(), isConstant);
-    }
-
     public CryptaLeaf(char[] word) {
         this(word, false);
     }

--- a/src/main/java/cryptator/tree/CryptaNode.java
+++ b/src/main/java/cryptator/tree/CryptaNode.java
@@ -13,60 +13,60 @@ import cryptator.specs.ICryptaNode;
 
 public class CryptaNode implements ICryptaNode {
 
-    private final CryptaOperator operator;
+	private final CryptaOperator operator;
 
-    private final ICryptaNode leftChild;
+	private final ICryptaNode leftChild;
 
-    private final ICryptaNode rightChild;
+	private final ICryptaNode rightChild;
 
-    public CryptaNode(String operator, ICryptaNode leftChild, ICryptaNode rightChild) {
-        this(CryptaOperator.valueOfToken(operator), leftChild, rightChild);
-    }
+	public CryptaNode(String operator, ICryptaNode leftChild, ICryptaNode rightChild) {
+		this(CryptaOperator.valueOfToken(operator), leftChild, rightChild);
+	}
 
-    public CryptaNode(CryptaOperator operator, ICryptaNode leftChild, ICryptaNode rightChild) {
-        this.operator = operator;
-        this.leftChild = leftChild;
-        this.rightChild = rightChild;
-    }
+	public CryptaNode(CryptaOperator operator, ICryptaNode leftChild, ICryptaNode rightChild) {
+		this.operator = operator;
+		this.leftChild = leftChild;
+		this.rightChild = rightChild;
+	}
 
-    @Override
-    public CryptaOperator getOperator() {
-        return operator;
-    }
+	@Override
+	public CryptaOperator getOperator() {
+		return operator;
+	}
 
-    @Override
-    public char[] getWord() {
-        return operator.getToken().toCharArray();
-    }
+	@Override
+	public char[] getWord() {
+		return operator.getToken().toCharArray();
+	}
 
-    @Override
-    public ICryptaNode getLeftChild() {
-        return leftChild;
-    }
+	@Override
+	public ICryptaNode getLeftChild() {
+		return leftChild;
+	}
 
-    @Override
-    public ICryptaNode getRightChild() {
-        return rightChild;
-    }
+	@Override
+	public ICryptaNode getRightChild() {
+		return rightChild;
+	}
 
-    @Override
-    public boolean isLeaf() {
-        return false;
-    }
+	@Override
+	public boolean isLeaf() {
+		return false;
+	}
 
-    @Override
-    public boolean isConstant() {
-        return false;
-    }
+	@Override
+	public boolean isConstant() {
+		return false;
+	}
 
-    @Override
-    public boolean isInternalNode() {
-        return true;
-    }
+	@Override
+	public boolean isInternalNode() {
+		return true;
+	}
 
-    @Override
-    public String toString() {
-        return operator.getToken();
-    }
+	@Override
+	public String toString() {
+		return operator.getToken();
+	}
 
 }

--- a/src/main/java/cryptator/tree/CryptaNode.java
+++ b/src/main/java/cryptator/tree/CryptaNode.java
@@ -50,12 +50,12 @@ public class CryptaNode implements ICryptaNode {
 	}
 
 	@Override
-	public boolean isLeaf() {
+	public boolean isConstantLeaf() {
 		return false;
 	}
 
 	@Override
-	public boolean isConstant() {
+	public boolean isWordLeaf() {
 		return false;
 	}
 

--- a/src/main/java/cryptator/tree/CryptaNode.java
+++ b/src/main/java/cryptator/tree/CryptaNode.java
@@ -69,4 +69,7 @@ public class CryptaNode implements ICryptaNode {
 		return operator.getToken();
 	}
 
+	public String write(){
+		return operator.getToken();
+	}
 }

--- a/src/main/java/cryptator/tree/CryptaNode.java
+++ b/src/main/java/cryptator/tree/CryptaNode.java
@@ -13,55 +13,60 @@ import cryptator.specs.ICryptaNode;
 
 public class CryptaNode implements ICryptaNode {
 
-	private final CryptaOperator operator;
+    private final CryptaOperator operator;
 
-	private final ICryptaNode leftChild;
+    private final ICryptaNode leftChild;
 
-	private final ICryptaNode rightChild;
+    private final ICryptaNode rightChild;
 
-	public CryptaNode(String operator, ICryptaNode leftChild, ICryptaNode rightChild) {
-		this(CryptaOperator.valueOfToken(operator), leftChild, rightChild);
-	}
+    public CryptaNode(String operator, ICryptaNode leftChild, ICryptaNode rightChild) {
+        this(CryptaOperator.valueOfToken(operator), leftChild, rightChild);
+    }
 
-	public CryptaNode(CryptaOperator operator, ICryptaNode leftChild, ICryptaNode rightChild) {
-		this.operator = operator;
-		this.leftChild = leftChild;
-		this.rightChild = rightChild;
-	}
+    public CryptaNode(CryptaOperator operator, ICryptaNode leftChild, ICryptaNode rightChild) {
+        this.operator = operator;
+        this.leftChild = leftChild;
+        this.rightChild = rightChild;
+    }
 
-	@Override
-	public CryptaOperator getOperator() {
-		return operator;
-	}
+    @Override
+    public CryptaOperator getOperator() {
+        return operator;
+    }
 
-	@Override
-	public char[] getWord() {
-		return operator.getToken().toCharArray();
-	}
+    @Override
+    public char[] getWord() {
+        return operator.getToken().toCharArray();
+    }
 
-	@Override
-	public ICryptaNode getLeftChild() {
-		return leftChild;
-	}
+    @Override
+    public ICryptaNode getLeftChild() {
+        return leftChild;
+    }
 
-	@Override
-	public ICryptaNode getRightChild() {
-		return rightChild;
-	}
+    @Override
+    public ICryptaNode getRightChild() {
+        return rightChild;
+    }
 
-	@Override
-	public boolean isLeaf() {
-		return false;
-	}
+    @Override
+    public boolean isLeaf() {
+        return false;
+    }
 
-	@Override
-	public boolean isInternalNode() {
-		return true;
-	}
+    @Override
+    public boolean isConstant() {
+        return false;
+    }
 
-	@Override
-	public String toString() {
-		return operator.getToken();
-	}
+    @Override
+    public boolean isInternalNode() {
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return operator.getToken();
+    }
 
 }

--- a/src/main/java/cryptator/tree/CryptaSymbols.java
+++ b/src/main/java/cryptator/tree/CryptaSymbols.java
@@ -25,7 +25,7 @@ public class CryptaSymbols implements ITraversalNodeConsumer {
 
     @Override
     public void accept(ICryptaNode node, int numNode) {
-        if (node.isLeaf() && !node.isConstant()) {
+        if (node.isWordLeaf()) {
             for (Character c : node.getWord()) {
                 letters.add(c);
             }

--- a/src/main/java/cryptator/tree/CryptaSymbols.java
+++ b/src/main/java/cryptator/tree/CryptaSymbols.java
@@ -8,39 +8,39 @@
  */
 package cryptator.tree;
 
+import cryptator.specs.ICryptaNode;
+import cryptator.specs.ITraversalNodeConsumer;
+
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
-import cryptator.specs.ICryptaNode;
-import cryptator.specs.ITraversalNodeConsumer;
-
 public class CryptaSymbols implements ITraversalNodeConsumer {
 
-	private Set<Character> letters;
+    private final Set<Character> letters;
 
-	public CryptaSymbols() {
-		this.letters = new HashSet<>();	
-	}
-	
-	@Override
-	public void accept(ICryptaNode node, int numNode) {
-		if(node.isLeaf()) {
-			for (Character c : node.getWord()) {
-				letters.add(c);
-			}
-		}
-	}
-	
-	
-	public char[] getSymbols() {
-		char[] res = new char[letters.size()];
-		int i = 0;
-		for (Character character : letters) {
-			res[i++] = character;
-		}
-		Arrays.sort(res);
-		return res;
-	}
-	
+    public CryptaSymbols() {
+        this.letters = new HashSet<>();
+    }
+
+    @Override
+    public void accept(ICryptaNode node, int numNode) {
+        if (node.isLeaf() && !node.isConstant()) {
+            for (Character c : node.getWord()) {
+                letters.add(c);
+            }
+        }
+    }
+
+
+    public char[] getSymbols() {
+        char[] res = new char[letters.size()];
+        int i = 0;
+        for (Character character : letters) {
+            res[i++] = character;
+        }
+        Arrays.sort(res);
+        return res;
+    }
+
 }

--- a/src/main/java/cryptator/tree/TreeUtils.java
+++ b/src/main/java/cryptator/tree/TreeUtils.java
@@ -24,11 +24,11 @@ public final class TreeUtils {
     }
 
     private static void writeWord(ICryptaNode node, PrintWriter out) {
-        if (node.isConstant()) out.write("'");
+        if (node.isConstantLeaf()) out.write("'");
         char[] w = node.getWord();
         if (w.length > 0) out.write(node.getWord());
         else out.write(ZERO);
-        if (node.isConstant()) out.write("'");
+        if (node.isConstantLeaf()) out.write("'");
         out.write(" ");
     }
 

--- a/src/main/java/cryptator/tree/TreeUtils.java
+++ b/src/main/java/cryptator/tree/TreeUtils.java
@@ -8,78 +8,81 @@
  */
 package cryptator.tree;
 
+import cryptator.CryptaOperator;
+import cryptator.specs.ICryptaNode;
+
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStream;
 import java.io.PrintWriter;
 
-import cryptator.CryptaOperator;
-import cryptator.specs.ICryptaNode;
-
 
 public final class TreeUtils {
 
-	public static final String ZERO = "_0";
+    public static final String ZERO = "_0";
 
-	private TreeUtils() {}
+    private TreeUtils() {
+    }
 
-	private static void writeWord(ICryptaNode node, PrintWriter out) {
-		char[] w = node.getWord();
-		if(w.length > 0) out.write(node.getWord());
-		else out.write(ZERO);
-		out.write(" ");
-	}
+    private static void writeWord(ICryptaNode node, PrintWriter out) {
+        if (node.isConstant()) out.write("'");
+        char[] w = node.getWord();
+        if (w.length > 0) out.write(node.getWord());
+        else out.write(ZERO);
+        if (node.isConstant()) out.write("'");
+        out.write(" ");
+    }
 
-	public static void writePreorder(ICryptaNode root, OutputStream outstream) {
-		final PrintWriter out = new PrintWriter(outstream);
-		TreeTraversals.preorderTraversal(root, (node, num) -> writeWord(node, out));
-		out.flush();
-	}
+    public static void writePreorder(ICryptaNode root, OutputStream outstream) {
+        final PrintWriter out = new PrintWriter(outstream);
+        TreeTraversals.preorderTraversal(root, (node, num) -> writeWord(node, out));
+        out.flush();
+    }
 
 
-	public static void printPostorder(ICryptaNode root) {
-		writePostorder(root, System.out);
-		System.out.println();
-	}
+    public static void printPostorder(ICryptaNode root) {
+        writePostorder(root, System.out);
+        System.out.println();
+    }
 
-	public static void writePostorder(ICryptaNode root, OutputStream outstream) {
-		final PrintWriter out = new PrintWriter(outstream);
-		TreeTraversals.postorderTraversal(root, (node, num) -> writeWord(node, out));
-		out.flush();
-	}
+    public static void writePostorder(ICryptaNode root, OutputStream outstream) {
+        final PrintWriter out = new PrintWriter(outstream);
+        TreeTraversals.postorderTraversal(root, (node, num) -> writeWord(node, out));
+        out.flush();
+    }
 
-	public static void printInorder(ICryptaNode root) {
-		writeInorder(root, System.out);
-		System.out.println();
-	}
+    public static void printInorder(ICryptaNode root) {
+        writeInorder(root, System.out);
+        System.out.println();
+    }
 
-	public static void writeInorder(ICryptaNode root, OutputStream outstream) {
-		final PrintWriter out = new PrintWriter(outstream);
-		TreeTraversals.inorderTraversal(root, (node, num) -> writeWord(node, out));
-		out.flush();
-	}
+    public static void writeInorder(ICryptaNode root, OutputStream outstream) {
+        final PrintWriter out = new PrintWriter(outstream);
+        TreeTraversals.inorderTraversal(root, (node, num) -> writeWord(node, out));
+        out.flush();
+    }
 
-	public static String writeInorder(ICryptaNode root) {
-		ByteArrayOutputStream out = new ByteArrayOutputStream();
-		TreeUtils.writeInorder(root, out);
-		return out.toString();
-	}
+    public static String writeInorder(ICryptaNode root) {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        TreeUtils.writeInorder(root, out);
+        return out.toString();
+    }
 
-	public static CryptaFeatures computeFeatures(ICryptaNode cryptarithm) {
-		final CryptaFeatures feat = new CryptaFeatures();
-		TreeTraversals.preorderTraversal(cryptarithm, feat);
-		return feat;
-	}
+    public static CryptaFeatures computeFeatures(ICryptaNode cryptarithm) {
+        final CryptaFeatures feat = new CryptaFeatures();
+        TreeTraversals.preorderTraversal(cryptarithm, feat);
+        return feat;
+    }
 
-	public static CryptaOperatorDetection computeUnsupportedBignumOperator(ICryptaNode cryptarithm) {
-		final CryptaOperatorDetection detect = new CryptaOperatorDetection(CryptaOperator.ID, CryptaOperator.ADD, CryptaOperator.EQ, CryptaOperator.AND);
-		TreeTraversals.preorderTraversal(cryptarithm, detect);
-		return detect;
-	}
+    public static CryptaOperatorDetection computeUnsupportedBignumOperator(ICryptaNode cryptarithm) {
+        final CryptaOperatorDetection detect = new CryptaOperatorDetection(CryptaOperator.ID, CryptaOperator.ADD, CryptaOperator.EQ, CryptaOperator.AND);
+        TreeTraversals.preorderTraversal(cryptarithm, detect);
+        return detect;
+    }
 
-	public static char[] computeSymbols(ICryptaNode cryptarithm) {
-		final CryptaSymbols sym = new CryptaSymbols();
-		TreeTraversals.preorderTraversal(cryptarithm, sym);
-		return sym.getSymbols();
-	}
+    public static char[] computeSymbols(ICryptaNode cryptarithm) {
+        final CryptaSymbols sym = new CryptaSymbols();
+        TreeTraversals.preorderTraversal(cryptarithm, sym);
+        return sym.getSymbols();
+    }
 
 }

--- a/src/main/java/cryptator/tree/TreeUtils.java
+++ b/src/main/java/cryptator/tree/TreeUtils.java
@@ -24,11 +24,9 @@ public final class TreeUtils {
     }
 
     private static void writeWord(ICryptaNode node, PrintWriter out) {
-        if (node.isConstantLeaf()) out.write("'");
         char[] w = node.getWord();
-        if (w.length > 0) out.write(node.getWord());
+        if (w.length > 0) out.write(node.write());
         else out.write(ZERO);
-        if (node.isConstantLeaf()) out.write("'");
         out.write(" ");
     }
 

--- a/src/test/java/cryptator/BignumTest.java
+++ b/src/test/java/cryptator/BignumTest.java
@@ -8,12 +8,13 @@
  */
 package cryptator;
 
+import org.junit.BeforeClass;
+import org.junit.Test;
+
 import cryptator.parser.CryptaParserException;
 import cryptator.solver.CryptaModelException;
 import cryptator.solver.CryptaSolver;
 import cryptator.solver.CryptaSolverException;
-import org.junit.BeforeClass;
-import org.junit.Test;
 
 public class BignumTest {
 
@@ -149,6 +150,63 @@ public class BignumTest {
 				"A + A + A + A + A = E";
 		t.testSAT(str);
 		t.testUNIQUE(str);
+	}
+
+	// Tests with ints
+	@Test
+	public void testIntegers01() throws CryptaParserException, CryptaModelException, CryptaSolverException {
+		t.testUNSAT("s='1'; send+more=money");
+	}
+
+	@Test
+	public void testIntegers02() throws CryptaParserException, CryptaModelException, CryptaSolverException {
+		t.testUNIQUE("m='1'; send+more=money");
+	}
+
+	@Test
+	public void testIntegers03() throws CryptaParserException, CryptaModelException, CryptaSolverException {
+		t.testNotUNIQUE("a='1'; a+b=d");
+	}
+
+	@Test
+	public void testIntegers04() throws CryptaParserException, CryptaModelException, CryptaSolverException {
+		t.testUNIQUE("a='1'; b='2'+a; a+b=d");
+	}
+	@Test
+	public void testIntegers05() throws CryptaParserException, CryptaModelException, CryptaSolverException {
+		t.testUNIQUE("'11'+'33'='44'");
+	}
+
+	@Test
+	public void testIntegers06() throws CryptaParserException, CryptaModelException, CryptaSolverException {
+		var test = "r='4'; false=true+maybe;s='3'; y=f+s;u='6'; ";
+		t.testSAT(test);
+		t.testUNIQUE(test);
+	}
+
+	@Test
+	public void testIntegers07() throws CryptaParserException, CryptaModelException, CryptaSolverException {
+		t.testUNSAT("'11'+'33'='45'");
+	}
+
+	@Test
+	public void testIntegers08() throws CryptaParserException, CryptaModelException, CryptaSolverException {
+		var test = "r='4'; false=true+maybe;s='3'; y=f+s+'12';u='6'; ";
+		t.testUNSAT(test);
+	}
+
+	@Test
+	public void testSetBase1() throws CryptaParserException, CryptaModelException, CryptaSolverException {
+		var test = "r='36' ";
+		t.config.setArithmeticBase(40);
+		t.testUNIQUE(test);
+	}
+
+	@Test
+	public void testSetBase2() throws CryptaParserException, CryptaModelException, CryptaSolverException {
+		var test = "1AB52='109394'";
+		t.config.setArithmeticBase(16);
+		t.testUNIQUE(test);
 	}
 
 	// Tests from SolverTest class

--- a/src/test/java/cryptator/EvaluationTest.java
+++ b/src/test/java/cryptator/EvaluationTest.java
@@ -275,4 +275,32 @@ public class EvaluationTest {
         assertTrueEval(cryptarithm, solution, 10);
     }
 
+    // Integer test evaluation
+    @Test
+    public void testEvaluationInteger1() throws CryptaParserException, CryptaSolutionException, CryptaEvaluationException {
+        final ICryptaNode cryptarithm = parser.parse("a='2'");
+        final ICryptaSolution solution = CryptaSolutionMap.parseSolution("a=2");
+        assertTrueEval(cryptarithm, solution, 10);
+    }
+
+    @Test
+    public void testEvaluationInteger2() throws CryptaParserException, CryptaSolutionException, CryptaEvaluationException {
+        final ICryptaNode cryptarithm = parser.parse("a+'22'='31'");
+        final ICryptaSolution solution = CryptaSolutionMap.parseSolution("a=9");
+        assertTrueEval(cryptarithm, solution, 10);
+    }
+
+    @Test
+    public void testEvaluationInteger3() throws CryptaParserException, CryptaSolutionException, CryptaEvaluationException {
+        final ICryptaNode cryptarithm = parser.parse("a+'22'='31'");
+        final ICryptaSolution solution = CryptaSolutionMap.parseSolution("a=8");
+        assertFalseEval(cryptarithm, solution, 10);
+    }
+
+    @Test
+    public void testEvaluationIntegerFail1() throws CryptaParserException, CryptaSolutionException, CryptaEvaluationException {
+        final ICryptaNode cryptarithm = parser.parse("a+'22'='31'");
+        final ICryptaSolution solution = CryptaSolutionMap.parseSolution("a=8");
+        assertFalseEval(cryptarithm, solution, 10);
+    }
 }

--- a/src/test/java/cryptator/EvaluationTest.java
+++ b/src/test/java/cryptator/EvaluationTest.java
@@ -8,6 +8,12 @@
  */
 package cryptator;
 
+import static org.junit.Assert.*;
+
+import java.math.BigInteger;
+
+import org.junit.Test;
+
 import cryptator.parser.CryptaParserException;
 import cryptator.parser.CryptaParserWrapper;
 import cryptator.solver.CryptaSolutionException;
@@ -19,11 +25,6 @@ import cryptator.tree.CryptaEvaluation;
 import cryptator.tree.CryptaEvaluationException;
 import cryptator.tree.CryptaLeaf;
 import cryptator.tree.CryptaNode;
-import org.junit.Test;
-
-import java.math.BigInteger;
-
-import static org.junit.Assert.*;
 
 public class EvaluationTest {
 
@@ -302,5 +303,26 @@ public class EvaluationTest {
         final ICryptaNode cryptarithm = parser.parse("a+'22'='31'");
         final ICryptaSolution solution = CryptaSolutionMap.parseSolution("a=8");
         assertFalseEval(cryptarithm, solution, 10);
+    }
+
+    @Test
+    public void testSetBaseInteger1() throws CryptaParserException, CryptaSolutionException, CryptaEvaluationException {
+        final ICryptaNode cryptarithm = parser.parse("1AB52='109394'");
+        final ICryptaSolution solution = CryptaSolutionMap.parseSolution("1=1 A=10 B=11 5=5 2=2");
+        assertTrueEval(cryptarithm, solution, 16);
+    }
+
+    @Test
+    public void testSetBaseInteger2() throws CryptaParserException, CryptaSolutionException, CryptaEvaluationException {
+        final ICryptaNode cryptarithm = parser.parse("1AB52='109394'+'1'");
+        final ICryptaSolution solution = CryptaSolutionMap.parseSolution("1=1 A=10 B=11 5=5 2=2");
+        assertFalseEval(cryptarithm, solution, 16);
+    }
+
+    @Test
+    public void testSetBaseInteger3() throws CryptaParserException, CryptaSolutionException, CryptaEvaluationException {
+        final ICryptaNode cryptarithm = parser.parse("1AB52='109394'+'1'");
+        final ICryptaSolution solution = CryptaSolutionMap.parseSolution("1=1 A=10 B=11 5=5 2=3");
+        assertTrueEval(cryptarithm, solution, 16);
     }
 }

--- a/src/test/java/cryptator/FeaturesTest.java
+++ b/src/test/java/cryptator/FeaturesTest.java
@@ -8,15 +8,16 @@
  */
 package cryptator;
 
-import org.junit.Test;
-
 import cryptator.parser.CryptaParserException;
 import cryptator.parser.CryptaParserWrapper;
 import cryptator.specs.ICryptaNode;
 import cryptator.tree.CryptaFeatures;
 import cryptator.tree.TreeUtils;
+import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 public class FeaturesTest {
 
 	public final CryptaParserWrapper parser = new CryptaParserWrapper();
@@ -26,14 +27,16 @@ public class FeaturesTest {
 
 	@Test
 	public void testFeatures1() throws CryptaParserException {
-		final ICryptaNode node = parser.parse("send+more=money");
+		final ICryptaNode node = parser.parse("send+more=money + '0'");
 		final CryptaFeatures feat = TreeUtils.computeFeatures(node);
 		assertEquals(3, feat.getWordCount());
+		assertEquals(1, feat.getConstantCount());
 		assertEquals(13, feat.getCharCount());
 		assertEquals(4, feat.getMinWordLength());
-		assertEquals(5, feat.getMaxWordLength());		
+		assertEquals(5, feat.getMaxWordLength());
 		assertEquals(8, feat.getSymbols().size());
-		assertEquals(2, feat.getOperators().size());	
+		assertEquals(2, feat.getOperators().size());
+		assertTrue(feat.getConstants().contains(0));
 	}
 	
 	@Test

--- a/src/test/java/cryptator/ParserTest.java
+++ b/src/test/java/cryptator/ParserTest.java
@@ -1,8 +1,8 @@
 /**
  * This file is part of cryptator, https://github.com/arnaud-m/cryptator
- *
+ * <p>
  * Copyright (c) 2022, Université Côte d'Azur. All rights reserved.
- *
+ * <p>
  * Licensed under the BSD 3-clause license.
  * See LICENSE file in the project root for full license information.
  */
@@ -159,7 +159,6 @@ public class ParserTest {
         testPreorder("; = + send more money >= + d e y ", node);
         testPostorder("send more + money = d e + y >= ; ", node);
         testInorder("send + more = money ; d + e >= y ", node);
-
     }
 
     @Test
@@ -219,6 +218,26 @@ public class ParserTest {
     @Test(expected = CryptaParserException.class)
     public void testParserErrorAND7() throws CryptaParserException {
         parser.parse(";a=b; b=c;");
+    }
+
+    // Test on parse integers
+    @Test
+    public void testParserInteger1() throws CryptaParserException {
+        final ICryptaNode node = parser.parse("send+more='1234';; d+e>=y");
+
+        testPreorder("; = + send more 1234 >= + d e y ", node);
+        testPostorder("send more + 1234 = d e + y >= ; ", node);
+        testInorder("send + more = 1234 ; d + e >= y ", node);
+    }
+
+    @Test(expected = CryptaParserException.class)
+    public void testParserIntegerError1() throws CryptaParserException {
+        parser.parse("send + more >= money; 1 + 'aabc' = 3");
+    }
+
+    @Test(expected = CryptaParserException.class)
+    public void testParserIntegerError2() throws CryptaParserException {
+        parser.parse("send + more >= money; 1 + '12a45' = 3");
     }
 
 }

--- a/src/test/java/cryptator/ParserTest.java
+++ b/src/test/java/cryptator/ParserTest.java
@@ -1,8 +1,8 @@
 /**
  * This file is part of cryptator, https://github.com/arnaud-m/cryptator
- * <p>
+ *
  * Copyright (c) 2022, Université Côte d'Azur. All rights reserved.
- * <p>
+ *
  * Licensed under the BSD 3-clause license.
  * See LICENSE file in the project root for full license information.
  */

--- a/src/test/java/cryptator/ParserTest.java
+++ b/src/test/java/cryptator/ParserTest.java
@@ -225,9 +225,9 @@ public class ParserTest {
     public void testParserInteger1() throws CryptaParserException {
         final ICryptaNode node = parser.parse("send+more='1234';; d+e>=y");
 
-        testPreorder("; = + send more 1234 >= + d e y ", node);
-        testPostorder("send more + 1234 = d e + y >= ; ", node);
-        testInorder("send + more = 1234 ; d + e >= y ", node);
+        testPreorder("; = + send more '1234' >= + d e y ", node);
+        testPostorder("send more + '1234' = d e + y >= ; ", node);
+        testInorder("send + more = '1234' ; d + e >= y ", node);
     }
 
     @Test(expected = CryptaParserException.class)

--- a/src/test/java/cryptator/SolverTest.java
+++ b/src/test/java/cryptator/SolverTest.java
@@ -434,6 +434,7 @@ public class SolverTest {
                 "DE * DGC = EBAH; " +
                 "CFGH-JGKK=FAGH");
     }
+
     @Test
     public void testCrossNumber2() throws CryptaParserException, CryptaModelException, CryptaSolverException {
         t.testUNSAT("ABC * DE = CFGH; " +
@@ -485,5 +486,98 @@ public class SolverTest {
     public void testSendMoreMoneyList6() throws CryptaParserException, CryptaModelException, CryptaSolverException {
         t.config.setHornerScheme(true);
         t.testUNSAT("send+more=money; s+e=n;");
+    }
+
+    // Long multiplication with integer
+    /*
+        SEE * SO = MIMEO
+        MIMEO = EMOO + 10*MESS
+        SEE * O = EMOO
+        SEE * S = MESS
+     */
+    @Test
+    public void testEvaluationLongMultiplication1() throws CryptaParserException, CryptaSolverException, CryptaModelException {
+        var cryptarithm = "SEE * SO = MIMEO; MIMEO = EMOO + '10'*MESS;SEE * O = EMOO;SEE * S = MESS";
+        t.testSAT(cryptarithm);
+        t.testUNIQUE(cryptarithm);
+    }
+
+    /*
+             C U T
+               I T
+           ---------
+           B U S T
+         T N N T
+         -----------
+         T E N E T
+     */
+    @Test
+    public void testEvaluationLongMultiplication2() throws CryptaParserException, CryptaSolverException, CryptaModelException {
+        var cryptarithm = "CUT * T = BUST; CUT * I = TNNT; TNNT * '10' + BUST = TENET; TENET = CUT * IT";
+        t.testSAT(cryptarithm);
+        t.testUNIQUE(cryptarithm);
+    }
+
+    /*
+                R E D
+                  A S
+             ---------
+              A R C S
+              R E D
+             ---------
+              C D T S
+     */
+    @Test
+    public void testEvaluationLongMultiplication3() throws CryptaParserException, CryptaSolverException, CryptaModelException {
+        var cryptarithm = "RED * S = ARCS; RED * A = RED; RED * '10' + ARCS = CDTS; CDTS = RED * AS";
+        t.testSAT(cryptarithm);
+        t.testUNIQUE(cryptarithm);
+    }
+
+    @Test
+    public void testEvaluationLongMultiplicationFail3() throws CryptaParserException, CryptaSolverException, CryptaModelException {
+        var cryptarithm = "RED * S = ARCS; RED * A = RED; RED * '10' + ARCS = CDTS; CDTS = RED * AS + '1'";
+        t.testUNSAT(cryptarithm);
+    }
+
+    /*
+                H O W
+                  W E
+             ---------
+              H A I L
+              P A L
+             ---------
+              L H A L
+     */
+    @Test
+    public void testEvaluationLongMultiplication4() throws CryptaParserException, CryptaSolverException, CryptaModelException {
+        var cryptarithm = "HOW * E = HAIL; HOW * W = PAL; HAIL + PAL * '10' = LHAL; HOW * WE = LHAL";
+        t.testSAT(cryptarithm);
+        t.testUNIQUE(cryptarithm);
+    }
+
+    // LONG DIVISION
+    /*
+                    K M
+              -----------
+       A K A / D A D D Y
+               D Y N A
+              -----------
+                 A R M Y
+                 A R K A
+                ---------
+                     R A
+     */
+    @Test
+    public void testEvaluationLongDivision1() throws CryptaParserException, CryptaSolverException, CryptaModelException {
+        var cryptarithm = "AKA * K = DYNA; DADD - DYNA = ARM; AKA * M = ARKA; ARMY - ARKA = RA; AKA * KM + RA = DADDY";
+        t.testSAT(cryptarithm);
+        t.testUNIQUE(cryptarithm);
+    }
+
+    @Test
+    public void testEvaluationLongDivisionFail1() throws CryptaParserException, CryptaSolverException, CryptaModelException {
+        var cryptarithm = "AKA * K = DYNA; DADD + DYNA = ARM; AKA * M = ARKA; ARMY - ARKA = RA; AKA * KM + RA = DADDY";
+        t.testUNSAT(cryptarithm);
     }
 }

--- a/src/test/java/cryptator/SolverTest.java
+++ b/src/test/java/cryptator/SolverTest.java
@@ -8,6 +8,16 @@
  */
 package cryptator;
 
+import static org.junit.Assert.*;
+
+import java.math.BigInteger;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+
 import cryptator.config.CryptaConfig;
 import cryptator.parser.CryptaParserException;
 import cryptator.parser.CryptaParserWrapper;
@@ -19,15 +29,6 @@ import cryptator.specs.ICryptaNode;
 import cryptator.specs.ICryptaSolver;
 import cryptator.tree.CryptaEvaluation;
 import cryptator.tree.CryptaEvaluationException;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Ignore;
-import org.junit.Test;
-
-import java.math.BigInteger;
-import java.util.concurrent.atomic.AtomicInteger;
-
-import static org.junit.Assert.*;
 
 
 final class CryptaSolvingTester {
@@ -119,6 +120,19 @@ public class SolverTest {
         t.config.setArithmeticBase(16);
         t.solver.limitSolution(100);
         t.testSAT("send+more=money");
+    }
+    @Test
+    public void testSetBase1() throws CryptaParserException, CryptaModelException, CryptaSolverException {
+        var test = "r='36'";
+        t.config.setArithmeticBase(40);
+        t.testUNIQUE(test);
+    }
+
+    @Test
+    public void testSetBase2() throws CryptaParserException, CryptaModelException, CryptaSolverException {
+        var test = "1AB52='109394'";
+        t.config.setArithmeticBase(16);
+        t.testUNIQUE(test);
     }
 
     @Test

--- a/src/test/java/cryptator/SolverTest.java
+++ b/src/test/java/cryptator/SolverTest.java
@@ -8,16 +8,6 @@
  */
 package cryptator;
 
-import static org.junit.Assert.*;
-
-import java.math.BigInteger;
-import java.util.concurrent.atomic.AtomicInteger;
-
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Ignore;
-import org.junit.Test;
-
 import cryptator.config.CryptaConfig;
 import cryptator.parser.CryptaParserException;
 import cryptator.parser.CryptaParserWrapper;
@@ -29,6 +19,15 @@ import cryptator.specs.ICryptaNode;
 import cryptator.specs.ICryptaSolver;
 import cryptator.tree.CryptaEvaluation;
 import cryptator.tree.CryptaEvaluationException;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.math.BigInteger;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.*;
 
 
 final class CryptaSolvingTester {
@@ -593,5 +592,19 @@ public class SolverTest {
     public void testEvaluationLongDivisionFail1() throws CryptaParserException, CryptaSolverException, CryptaModelException {
         var cryptarithm = "AKA * K = DYNA; DADD + DYNA = ARM; AKA * M = ARKA; ARMY - ARKA = RA; AKA * KM + RA = DADDY";
         t.testUNSAT(cryptarithm);
+    }
+
+    // Test from issue 25
+    // 9END+M08E=10NEY is wrong because M is already assigned 1.
+    @Test
+    public void testEvaluationIssue_25_1() throws CryptaParserException, CryptaSolverException, CryptaModelException {
+        var cryptarithm = "9END+M08E=10NEY;1='1';0='0';9='9';8='8'";
+        t.testUNSAT(cryptarithm);
+    }
+    @Test
+    public void testEvaluationIssue_25_2() throws CryptaParserException, CryptaSolverException, CryptaModelException {
+        // TODO : modify this line for issue 39 to accept W = 0
+        var cryptarithm = "W='4'";
+        t.testUNIQUE(cryptarithm);
     }
 }


### PR DESCRIPTION
Breif summary:

1. Added Integer to parser -> They are surrounded by ticks (eg '45')
2. Add CryptaConstant class to represent a node in the tree containing an integer (it extends CryptaLeaf) and adds some methods:
   - getConstant to obtain the constant stored in it (it is in base 10)
   - changeBaseLittleEndian(int) -> returns the constant in the wanted base on the form of a integer list in little endian
3. Add isConstant method to ICryptaNode, it is a shortcut to instantof
4. Update CryptaBigNumModeler to represent in the correct base the constants and add them to the stack
5. For every modified or added methods, tests have been added 
6. Upgraded Java version to 17 (readme to be updated), in order to have enhanced switch and pattern matching in instanceof.

Now we are able to parse and analyse long multiplications (see [here](http://cryptarithms.awardspace.us/puzzles.html#multipl)) and long divisions  (see [here](http://cryptarithms.awardspace.us/puzzles.html#longdiv))